### PR TITLE
Flatten contracts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ gulp lint:contracts
 
 We use a hosted Ethereum node cluster - [Infura](https://infura.io) for deployment to main and test networks.
 
-Flattened contracts are in source control under `flattened` folder and can be generated via `yarn run flatten:contracts` which uses [solidity-flattener](https://github.com/BlockCatIO/solidity-flattener) which you can install via `pip3 install solidity-flattener`
+Flattened contracts are in source control under `flattened` folder and can be generated via `yarn run flatten:contracts` which uses [/solidity-steamroller](https://github.com/JoinColony/solidity-steamroller)

--- a/flattened/TokenAuthorityFlattened.sol
+++ b/flattened/TokenAuthorityFlattened.sol
@@ -1,0 +1,98 @@
+pragma solidity ^0.4.23;
+
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+contract DSAuthority {
+    function canCall(
+        address src, address dst, bytes4 sig
+    ) public view returns (bool);
+}
+
+contract DSAuthEvents {
+    event LogSetAuthority (address indexed authority);
+    event LogSetOwner     (address indexed owner);
+}
+
+contract DSAuth is DSAuthEvents {
+    DSAuthority  public  authority;
+    address      public  owner;
+
+    constructor() public {
+        owner = msg.sender;
+        emit LogSetOwner(msg.sender);
+    }
+
+    function setOwner(address owner_)
+        public
+        auth
+    {
+        owner = owner_;
+        emit LogSetOwner(owner);
+    }
+
+    function setAuthority(DSAuthority authority_)
+        public
+        auth
+    {
+        authority = authority_;
+        emit LogSetAuthority(authority);
+    }
+
+    modifier auth {
+        require(isAuthorized(msg.sender, msg.sig));
+        _;
+    }
+
+    function isAuthorized(address src, bytes4 sig) internal view returns (bool) {
+        if (src == address(this)) {
+            return true;
+        } else if (src == owner) {
+            return true;
+        } else if (authority == DSAuthority(0)) {
+            return false;
+        } else {
+            return authority.canCall(src, this, sig);
+        }
+    }
+}
+
+
+contract TokenAuthority is DSAuthority {
+  address public token;
+  mapping(address => mapping(bytes4 => bool)) authorizations;
+  
+  constructor(address _token, address _vesting, address _colonyMultiSig) public {
+    token = _token;
+    bytes4 transferSig = bytes4(keccak256("transfer(address,uint256)"));
+    bytes4 transferFromSig = bytes4(keccak256("transferFrom(address,address,uint256)"));
+    bytes4 mintSig = bytes4(keccak256("mint(uint256)"));
+
+    authorizations[_vesting][transferSig] = true;
+    authorizations[_vesting][transferFromSig] = true;
+    authorizations[_colonyMultiSig][transferSig] = true;
+    authorizations[_colonyMultiSig][transferFromSig] = true;
+    authorizations[_colonyMultiSig][mintSig] = true;
+  }
+
+  function canCall(address src, address dst, bytes4 sig) public view returns (bool) {
+    if (dst != token) {
+      return false;
+    }
+    
+    return authorizations[src][sig];
+  }
+}

--- a/flattened/TokenFlattened.sol
+++ b/flattened/TokenFlattened.sol
@@ -1,4 +1,23 @@
-pragma solidity ^0.4.13;
+pragma solidity ^0.4.23;
+pragma experimental "v0.5.0";
+
+
+
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
 
 contract DSAuthority {
     function canCall(
@@ -15,9 +34,9 @@ contract DSAuth is DSAuthEvents {
     DSAuthority  public  authority;
     address      public  owner;
 
-    function DSAuth() public {
+    constructor() public {
         owner = msg.sender;
-        LogSetOwner(msg.sender);
+        emit LogSetOwner(msg.sender);
     }
 
     function setOwner(address owner_)
@@ -25,7 +44,7 @@ contract DSAuth is DSAuthEvents {
         auth
     {
         owner = owner_;
-        LogSetOwner(owner);
+        emit LogSetOwner(owner);
     }
 
     function setAuthority(DSAuthority authority_)
@@ -33,7 +52,7 @@ contract DSAuth is DSAuthEvents {
         auth
     {
         authority = authority_;
-        LogSetAuthority(authority);
+        emit LogSetAuthority(authority);
     }
 
     modifier auth {
@@ -53,27 +72,22 @@ contract DSAuth is DSAuthEvents {
         }
     }
 }
+/// math.sol -- mixin for inline numerical wizardry
 
-contract ERC20Events {
-    event Approval(address indexed src, address indexed guy, uint wad);
-    event Transfer(address indexed src, address indexed dst, uint wad);
-}
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 
-contract ERC20 is ERC20Events {
-    function totalSupply() public view returns (uint);
-    function balanceOf(address guy) public view returns (uint);
-    function allowance(address src, address guy) public view returns (uint);
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
 
-    function approve(address guy, uint wad) public returns (bool);
-    function transfer(address dst, uint wad) public returns (bool);
-    function transferFrom(
-        address src, address dst, uint wad
-    ) public returns (bool);
-}
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-contract ERC20Extended is ERC20 {
-  function mint(uint wad) public;
-}
+
 
 contract DSMath {
     function add(uint x, uint y) internal pure returns (uint z) {
@@ -142,6 +156,60 @@ contract DSMath {
         }
     }
 }
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+
+
+/// erc20.sol -- API for the ERC20 token standard
+
+// See <https://github.com/ethereum/EIPs/issues/20>.
+
+// This file likely does not meet the threshold of originality
+// required for copyright to apply.  As a result, this is free and
+// unencumbered software belonging to the public domain.
+
+
+
+contract ERC20Events {
+    event Approval(address indexed src, address indexed guy, uint wad);
+    event Transfer(address indexed src, address indexed dst, uint wad);
+}
+
+contract ERC20 is ERC20Events {
+    function totalSupply() public view returns (uint);
+    function balanceOf(address guy) public view returns (uint);
+    function allowance(address src, address guy) public view returns (uint);
+
+    function approve(address guy, uint wad) public returns (bool);
+    function transfer(address dst, uint wad) public returns (bool);
+    function transferFrom(
+        address src, address dst, uint wad
+    ) public returns (bool);
+}
+
+
+contract ERC20Extended is ERC20 {
+  event Mint(address indexed guy, uint wad);
+
+  function mint(uint wad) public;
+}
+
 
 contract Token is DSAuth, DSMath, ERC20Extended {
   bytes32 public symbol;
@@ -151,11 +219,20 @@ contract Token is DSAuth, DSMath, ERC20Extended {
   uint256 _supply;
   mapping (address => uint256) _balances;
   mapping (address => mapping (address => uint256)) _approvals;
+  bool public locked;
 
-  function Token(bytes32 _name, bytes32 _symbol, uint256 _decimals) public {
+  constructor(bytes32 _name, bytes32 _symbol, uint256 _decimals) public {
     name = _name;
     symbol = _symbol;
     decimals = _decimals;
+    locked = true;
+  }
+
+  modifier unlocked {
+    if (locked) {
+      require(isAuthorized(msg.sender, msg.sig));
+    }
+    _;
   }
 
   function totalSupply() public view returns (uint256) {
@@ -171,21 +248,17 @@ contract Token is DSAuth, DSMath, ERC20Extended {
   }
 
   function transfer(address dst, uint wad) public returns (bool) {
-    assert(_balances[msg.sender] >= wad);
-
-    _balances[msg.sender] = sub(_balances[msg.sender], wad);
-    _balances[dst] = add(_balances[dst], wad);
-
-    emit Transfer(msg.sender, dst, wad);
-
-    return true;
+    return transferFrom(msg.sender, dst, wad);
   }
 
-  function transferFrom(address src, address dst, uint wad) public returns (bool) {
-    assert(_balances[src] >= wad);
-    assert(_approvals[src][msg.sender] >= wad);
+  function transferFrom(address src, address dst, uint wad) public
+  unlocked
+  returns (bool)
+  {
+    if (src != msg.sender) {
+      _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
+    }
 
-    _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
     _balances[src] = sub(_balances[src], wad);
     _balances[dst] = add(_balances[dst], wad);
 
@@ -207,6 +280,14 @@ contract Token is DSAuth, DSMath, ERC20Extended {
   {
     _balances[msg.sender] = add(_balances[msg.sender], wad);
     _supply = add(_supply, wad);
+
+    emit Mint(msg.sender, wad);
+  }
+
+  function unlock() public
+  auth
+  {
+    require(locked);
+    locked = false;
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pretest:contracts:coverage": "sed -ie \"s/eth-gas-reporter/mocha-circleci-reporter/g\" ./truffle.js && rimraf ./truffle.jse",
     "posttest:contracts": "npm run stop:blockchain:client",
     "posttest:contracts:gasCosts": "npm run stop:blockchain:client",
-    "flatten:contracts": "solidity_flattener contracts/Token.sol --output flattened/TokenFlattened.sol --solc-paths=lib/dappsys/auth.sol && solidity_flattener contracts/Vesting.sol --output flattened/VestingFlattened.sol --solc-paths=lib/dappsys/auth.sol"
+    "flatten:contracts": "steamroller contracts/Token.sol > flattened/TokenFlattened.sol && steamroller contracts/TokenAuthority.sol > flattened/TokenAuthorityFlattened.sol && steamroller contracts/Vesting.sol > flattened/VestingFlattened.sol"
   },
   "pre-commit": [
     "eslint-staged",
@@ -66,6 +66,7 @@
     "rimraf": "^2.6.2",
     "shortid": "^2.2.8",
     "solidity-coverage": "^0.5.0",
+    "solidity-steamroller": "^1.0.0",
     "solium": "^1.1.7",
     "truffle": "^4.1.7",
     "web3-utils": "^1.0.0-beta.34"

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,7 +384,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -6237,6 +6237,10 @@ solidity-coverage@^0.5.0:
     solidity-parser-sc "0.4.8"
     web3 "^0.18.4"
 
+solidity-parser-antlr@^0.2.10:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.2.10.tgz#6bc9e48faf49c1bf7bb49562cc1900f25153171c"
+
 solidity-parser-sc@0.4.8:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/solidity-parser-sc/-/solidity-parser-sc-0.4.8.tgz#b2d14f0effe638f78b38b489cb4a763ad88613cd"
@@ -6244,6 +6248,13 @@ solidity-parser-sc@0.4.8:
     mocha "^2.4.5"
     pegjs "^0.10.0"
     yargs "^4.6.0"
+
+solidity-steamroller@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/solidity-steamroller/-/solidity-steamroller-1.0.0.tgz#a80ffa6019dab5a587ea5afd5295997af299a25d"
+  dependencies:
+    semver "^5.5.0"
+    solidity-parser-antlr "^0.2.10"
 
 solium-plugin-security@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
`solidity-flattener` started failing for solc 0.4.23 as logged in https://github.com/BlockCatIO/solidity-flattener/issues/26 

So @chmanie created an alternative without the `solc` dependency which we switch to instead here https://github.com/JoinColony/solidity-steamroller

