### PR TITLE
Reuse DSTokenBase in Colony token

### DIFF
--- a/contracts/ERC20Extended.sol
+++ b/contracts/ERC20Extended.sol
@@ -23,6 +23,9 @@ import "../lib/dappsys/erc20.sol";
 
 contract ERC20Extended is ERC20 {
   event Mint(address indexed guy, uint wad);
+  event Burn(address indexed guy, uint wad);
 
   function mint(uint wad) public;
+  
+  function burn(uint wad) public;
 }

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -38,12 +38,6 @@ contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
     _;
   }
 
-  function unlock() public
-  auth
-  {
-    locked = false;
-  }
-
   constructor(bytes32 _name, bytes32 _symbol, uint256 _decimals) public {
     name = _name;
     symbol = _symbol;
@@ -65,5 +59,18 @@ contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
     _supply = add(_supply, wad);
 
     emit Mint(msg.sender, wad);
+  }
+
+  function burn(uint wad) public {
+    _balances[msg.sender] = sub(_balances[msg.sender], wad);
+    _supply = sub(_supply, wad);
+
+    emit Burn(msg.sender, wad);
+  }
+
+  function unlock() public
+  auth
+  {
+    locked = false;
   }
 }

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -20,26 +20,16 @@ pragma experimental "v0.5.0";
 
 
 import "../lib/dappsys/auth.sol";
-import "../lib/dappsys/math.sol";
+import "../lib/dappsys/base.sol";
 import "./ERC20Extended.sol";
 
 
-contract Token is DSAuth, DSMath, ERC20Extended {
+contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
   bytes32 public symbol;
   uint256 public decimals;
   bytes32 public name;
 
-  uint256 _supply;
-  mapping (address => uint256) _balances;
-  mapping (address => mapping (address => uint256)) _approvals;
   bool public locked;
-
-  constructor(bytes32 _name, bytes32 _symbol, uint256 _decimals) public {
-    name = _name;
-    symbol = _symbol;
-    decimals = _decimals;
-    locked = true;
-  }
 
   modifier unlocked {
     if (locked) {
@@ -48,44 +38,24 @@ contract Token is DSAuth, DSMath, ERC20Extended {
     _;
   }
 
-  function totalSupply() public view returns (uint256) {
-    return _supply;
+  function unlock() public
+  auth
+  {
+    locked = false;
   }
 
-  function balanceOf(address src) public view returns (uint256) {
-    return _balances[src];
+  constructor(bytes32 _name, bytes32 _symbol, uint256 _decimals) public {
+    name = _name;
+    symbol = _symbol;
+    decimals = _decimals;
+    locked = true;
   }
 
-  function allowance(address src, address guy) public view returns (uint256) {
-    return _approvals[src][guy];
-  }
-
-  function transfer(address dst, uint wad) public returns (bool) {
-    return transferFrom(msg.sender, dst, wad);
-  }
-
-  function transferFrom(address src, address dst, uint wad) public
+  function transferFrom(address src, address dst, uint wad) public 
   unlocked
   returns (bool)
   {
-    if (src != msg.sender) {
-      _approvals[src][msg.sender] = sub(_approvals[src][msg.sender], wad);
-    }
-
-    _balances[src] = sub(_balances[src], wad);
-    _balances[dst] = add(_balances[dst], wad);
-
-    emit Transfer(src, dst, wad);
-
-    return true;
-  }
-
-  function approve(address guy, uint256 wad) public returns (bool) {
-    _approvals[msg.sender][guy] = wad;
-
-    emit Approval(msg.sender, guy, wad);
-
-    return true;
+    return super.transferFrom(src, dst, wad);
   }
 
   function mint(uint wad) public
@@ -95,11 +65,5 @@ contract Token is DSAuth, DSMath, ERC20Extended {
     _supply = add(_supply, wad);
 
     emit Mint(msg.sender, wad);
-  }
-
-  function unlock() public
-  auth
-  {
-    locked = false;
   }
 }

--- a/test/token.js
+++ b/test/token.js
@@ -151,10 +151,30 @@ contract("Token", accounts => {
       assert.equal(1500001, balance.toNumber());
     });
 
+    it("should emit a Mint event when minting tokens", async () => {
+      await expectEvent(token.mint(1), "Mint");
+    });
+
     it("should NOT be able to mint new tokens, when called by anyone NOT the Token owner", async () => {
       await checkErrorRevert(token.mint(1500000, { from: ACCOUNT_THREE }));
       const totalSupply = await token.totalSupply.call();
       assert.equal(0, totalSupply.toNumber());
+    });
+
+    it("should be able to burn tokens", async () => {
+      await token.mint(1500000);
+      await token.burn(500000);
+
+      const totalSupply = await token.totalSupply.call();
+      assert.equal(1000000, totalSupply.toNumber());
+
+      const balance = await token.balanceOf.call(COLONY_ACCOUNT);
+      assert.equal(1000000, balance.toNumber());
+    });
+
+    it("should emit a Burn event when burning tokens", async () => {
+      await token.mint(1);
+      await expectEvent(token.burn(1), "Burn");
     });
 
     it("should be able to unlock token by owner", async () => {


### PR DESCRIPTION
To avoid duplication of logic we can inherit the base ERC20 functionality from the `DSTokenBase` contract. We have to override the `transferFrom` implementation to introduce the `locked` modifier but this is fine as we can still call the base logic.

Here we introduce a `burn` Token function.