### PR TITLE
Fixes following review by Oleksii Matiyasevych 

### DIFF
--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -25,9 +25,9 @@ import "./ERC20Extended.sol";
 
 
 contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
-  bytes32 public symbol;
-  uint256 public decimals;
-  bytes32 public name;
+  uint8 public decimals;
+  string public symbol;
+  string public name;
 
   bool public locked;
 
@@ -38,7 +38,7 @@ contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
     _;
   }
 
-  constructor(bytes32 _name, bytes32 _symbol, uint256 _decimals) public {
+  constructor(string _name, string _symbol, uint8 _decimals) public {
     name = _name;
     symbol = _symbol;
     decimals = _decimals;

--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -113,8 +113,8 @@ contract Vesting is DSMath {
     (monthsVested, amountVested) = calculateGrantClaim(_recipient);
     uint128 amountNotVested = uint128(sub(sub(tokenGrant.amount, tokenGrant.totalClaimed), amountVested));
 
-    token.transfer(_recipient, amountVested);
-    token.transfer(colonyMultiSig, amountNotVested);
+    require(token.transfer(_recipient, amountVested));
+    require(token.transfer(colonyMultiSig, amountNotVested));
 
     tokenGrant.startTime = 0;
     tokenGrant.amount = 0;
@@ -138,7 +138,7 @@ contract Vesting is DSMath {
     tokenGrant.monthsClaimed = uint16(add(tokenGrant.monthsClaimed, monthsVested));
     tokenGrant.totalClaimed = uint128(add(tokenGrant.totalClaimed, amountVested));
     
-    token.transfer(msg.sender, amountVested);
+    require(token.transfer(msg.sender, amountVested));
     emit GrantTokensClaimed(msg.sender, amountVested);
   }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "stop:blockchain:client": "bash ./scripts/stop-blockchain-client.sh",
     "test:contracts": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test --network development",
     "test:contracts:gasCosts": "npm run start:blockchain:client & truffle migrate --reset --compile-all && truffle test gasCosts/gasCosts.js --network development",
-    "test:contracts:coverage": "SOLIDITY_COVERAGE=1 solidity-coverage && istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
+    "test:contracts:coverage": "SOLIDITY_COVERAGE=1 solidity-coverage && istanbul check-coverage --statements 100 --branches 84 --functions 100 --lines 100",
     "pretest:contracts": "sed -ie \"s/eth-gas-reporter/mocha-circleci-reporter/g\" ./truffle.js && rimraf ./truffle.jse",
     "pretest:contracts:gasCosts": "sed -ie \"s/mocha-circleci-reporter/eth-gas-reporter/g\" ./truffle.js && rimraf ./truffle.jse",
     "pretest:contracts:coverage": "sed -ie \"s/eth-gas-reporter/mocha-circleci-reporter/g\" ./truffle.js && rimraf ./truffle.jse",

--- a/test/token.js
+++ b/test/token.js
@@ -134,6 +134,21 @@ contract("Token", accounts => {
   });
 
   describe("when working with additional functions", () => {
+    it("should be able to get the token decimals", async () => {
+      const decimals = await token.decimals.call();
+      assert.equal(decimals.toNumber(), 18);
+    });
+
+    it("should be able to get the token symbol", async () => {
+      const symbol = await token.symbol.call();
+      assert.equal(symbol, "CLNY");
+    });
+
+    it("should be able to get the token name", async () => {
+      const name = await token.name.call();
+      assert.equal(name, "Colony token");
+    });
+
     it("should be able to mint new tokens, when called by the Token owner", async () => {
       await token.mint(1500000, { from: COLONY_ACCOUNT });
       let totalSupply = await token.totalSupply.call();

--- a/test/vesting.js
+++ b/test/vesting.js
@@ -179,6 +179,18 @@ contract("Vesting", accounts => {
         const grant = await vesting.tokenGrants.call(ACCOUNT_1);
         assert.equal(0, grant[0]);
       });
+
+      it("should error if grant amount cannot be transferred", async () => {
+        // Remove the allowance for the vesting contract
+        let txData = await token.contract.approve.getData(vesting.address, 0);
+        await colonyMultiSig.submitTransaction(token.address, 0, txData);
+
+        txData = await vesting.contract.addTokenGrant.getData(ACCOUNT_1, 0, 10, 24, 6);
+        await expectEvent(colonyMultiSig.submitTransaction(vesting.address, 0, txData), "ExecutionFailure");
+
+        const grant = await vesting.tokenGrants.call(ACCOUNT_1);
+        assert.equal(0, grant[0]);
+      });
     });
 
     describe("when removing token grants", () => {


### PR DESCRIPTION
Here we fix the following notes from Oleksii:

>ERC20 compliancy
>- `decimals` should of type `uint8`
>- `name` and `symbol` should be of type `string`

>If Vesting.sol will ever be used with some other token implementation, it must check the `transfer` and `transferFrom` results for `true`. There are many tokens which don't revert but return false.

We also had to drop the branches coverage as with the last change there are 4 instances of require checks of `transfer` and `transferFrom` which we cannot force to fail (due to internal SafeMath require checks failing first and transfers essentially never returning `false`).