### PR TITLE
Add regulator for token transfers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test-results.xml
 coverage.json
 /coverage
 /flattened/*
+**/build/*

--- a/build/contracts/TokenAuthority.json
+++ b/build/contracts/TokenAuthority.json
@@ -40,6 +40,10 @@
         {
           "name": "miners",
           "type": "address[]"
+        },
+        {
+          "name": "_regulator",
+          "type": "address"
         }
       ],
       "payable": false,
@@ -74,20 +78,20 @@
       "type": "function"
     }
   ],
-  "bytecode": "0x608060405234801561001057600080fd5b506040516106d13803806106d183398101806040528101908080519060200190929190805190602001909291908051906020019092919080519060200190929190805190602001909291908051820192919050505060008060008060008a6000806101000a815481600160a060020a030219169083600160a060020a0316021790555060405180807f7472616e7366657228616464726573732c75696e74323536290000000000000081525060190190506040518091039020945060405180807f7472616e7366657246726f6d28616464726573732c616464726573732c75696e81526020017f743235362900000000000000000000000000000000000000000000000000000081525060250190506040518091039020935060405180807f6d696e742875696e743235362900000000000000000000000000000000000000815250600d0190506040518091039020925060018060008c600160a060020a0316600160a060020a03168152602001908152602001600020600087600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008c600160a060020a0316600160a060020a03168152602001908152602001600020600086600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008b600160a060020a0316600160a060020a03168152602001908152602001600020600087600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008b600160a060020a0316600160a060020a03168152602001908152602001600020600085600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008a600160a060020a0316600160a060020a03168152602001908152602001600020600087600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008a600160a060020a0316600160a060020a03168152602001908152602001600020600086600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff021916908315150217905550600180600089600160a060020a0316600160a060020a03168152602001908152602001600020600087600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff021916908315150217905550600180600089600160a060020a0316600160a060020a03168152602001908152602001600020600086600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff021916908315150217905550600091505b85518210156104f057858281518110151561048d57fe5b6020908102909101810151600160a060020a0381166000908152600180845260408083207fffffffff000000000000000000000000000000000000000000000000000000008b168452909452929020805460ff1916831790559201919050610476565b50505050505050505050506101c78061050a6000396000f30060806040526004361061004b5763ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663b70096138114610050578063fc0c546a146100ba575b600080fd5b34801561005c57600080fd5b506100a673ffffffffffffffffffffffffffffffffffffffff600435811690602435167bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19604435166100f8565b604080519115158252519081900360200190f35b3480156100c657600080fd5b506100cf61017f565b6040805173ffffffffffffffffffffffffffffffffffffffff9092168252519081900360200190f35b6000805473ffffffffffffffffffffffffffffffffffffffff84811691161461012357506000610178565b5073ffffffffffffffffffffffffffffffffffffffff831660009081526001602090815260408083207bffffffffffffffffffffffffffffffffffffffffffffffffffffffff198516845290915290205460ff165b9392505050565b60005473ffffffffffffffffffffffffffffffffffffffff16815600a165627a7a723058206fd7551c92fe0da53ecec2da4eb1615f36290db971d59742c4031573e4def2380029",
-  "deployedBytecode": "0x60806040526004361061004b5763ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663b70096138114610050578063fc0c546a146100ba575b600080fd5b34801561005c57600080fd5b506100a673ffffffffffffffffffffffffffffffffffffffff600435811690602435167bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19604435166100f8565b604080519115158252519081900360200190f35b3480156100c657600080fd5b506100cf61017f565b6040805173ffffffffffffffffffffffffffffffffffffffff9092168252519081900360200190f35b6000805473ffffffffffffffffffffffffffffffffffffffff84811691161461012357506000610178565b5073ffffffffffffffffffffffffffffffffffffffff831660009081526001602090815260408083207bffffffffffffffffffffffffffffffffffffffffffffffffffffffff198516845290915290205460ff165b9392505050565b60005473ffffffffffffffffffffffffffffffffffffffff16815600a165627a7a723058206fd7551c92fe0da53ecec2da4eb1615f36290db971d59742c4031573e4def2380029",
-  "sourceMap": "762:1765:3:-;;;894:1448;8:9:-1;5:2;;;30:1;27;20:12;5:2;894:1448:3;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1084:18;1157:22;1246:14;2213:6;2257:13;1072:6;1064:5;;:14;;;;;-1:-1:-1;;;;;1064:14:3;;;;;-1:-1:-1;;;;;1064:14:3;;;;;;1112:38;;;;;;;;;;;;;;;;;;;1084:67;;1189:50;;;;;;;;;;;;;;;;;;;;;;;;1157:83;;1270:26;;;;;;;;;;;;;;;;;;;1246:51;;1350:4;1304:14;:30;1319:14;-1:-1:-1;;;;;1304:30:3;-1:-1:-1;;;;;1304:30:3;;;;;;;;;;;;:43;1335:11;-1:-1:-1;;;;;1304:43:3;;-1:-1:-1;;;;;1304:43:3;;;;;;;;;;;;;;:50;;;;;;;;;;;;;;;;;;1461:4;1411:14;:30;1426:14;-1:-1:-1;;;;;1411:30:3;-1:-1:-1;;;;;1411:30:3;;;;;;;;;;;;:47;1442:15;-1:-1:-1;;;;;1411:47:3;;-1:-1:-1;;;;;1411:47:3;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;1515:4;1472:14;:27;1487:11;-1:-1:-1;;;;;1472:27:3;-1:-1:-1;;;;;1472:27:3;;;;;;;;;;;;:40;1500:11;-1:-1:-1;;;;;1472:40:3;;-1:-1:-1;;;;;1472:40:3;;;;;;;;;;;;;;:47;;;;;;;;;;;;;;;;;;1733:4;1694:14;:27;1709:11;-1:-1:-1;;;;;1694:27:3;-1:-1:-1;;;;;1694:27:3;;;;;;;;;;;;:36;1722:7;-1:-1:-1;;;;;1694:36:3;;-1:-1:-1;;;;;1694:36:3;;;;;;;;;;;;;;:43;;;;;;;;;;;;;;;;;;1846:4;1801:14;:29;1816:13;-1:-1:-1;;;;;1801:29:3;-1:-1:-1;;;;;1801:29:3;;;;;;;;;;;;:42;1831:11;-1:-1:-1;;;;;1801:42:3;;-1:-1:-1;;;;;1801:42:3;;;;;;;;;;;;;;:49;;;;;;;;;;;;;;;;;;1944:4;1895:14;:29;1910:13;-1:-1:-1;;;;;1895:29:3;-1:-1:-1;;;;;1895:29:3;;;;;;;;;;;;:46;1925:15;-1:-1:-1;;;;;1895:46:3;;-1:-1:-1;;;;;1895:46:3;;;;;;;;;;;;;;:53;;;;;;;;;;;;;;;;;;2029:4;1989:14;:24;2004:8;-1:-1:-1;;;;;1989:24:3;-1:-1:-1;;;;;1989:24:3;;;;;;;;;;;;:37;2014:11;-1:-1:-1;;;;;1989:37:3;;-1:-1:-1;;;;;1989:37:3;;;;;;;;;;;;;;:44;;;;;;;;;;;;;;;;;;2083:4;2039:14;:24;2054:8;-1:-1:-1;;;;;2039:24:3;-1:-1:-1;;;;;2039:24:3;;;;;;;;;;;;:41;2064:15;-1:-1:-1;;;;;2039:41:3;;-1:-1:-1;;;;;2039:41:3;;;;;;;;;;;;;;:48;;;;;;;;;;;;;;;;;;2222:1;2213:10;;2208:130;2229:6;:13;2225:1;:17;2208:130;;;2273:6;2280:1;2273:9;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;2290:21:3;;;;;;2327:4;2290:21;;;;;;;:34;;;;;;;;;;;:41;;-1:-1:-1;;2290:41:3;;;;;2244:3;;;2273:9;-1:-1:-1;2208:130:3;;;894:1448;;;;;;;;;;;762:1765;;;;;;",
-  "deployedSourceMap": "762:1765:3:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;2346:179;;8:9:-1;5:2;;;30:1;27;20:12;5:2;-1:-1;2346:179:3;;;;;;;;;;-1:-1:-1;;2346:179:3;;;;;;;;;;;;;;;;;;;;;;;805:20;;8:9:-1;5:2;;;30:1;27;20:12;5:2;805:20:3;;;;;;;;;;;;;;;;;;;;;;;2346:179;2422:4;2445:5;;;2438:12;;;2445:5;;2438:12;2434:45;;-1:-1:-1;2467:5:3;2460:12;;2434:45;-1:-1:-1;2496:19:3;;;;;;;:14;:19;;;;;;;;-1:-1:-1;;2496:24:3;;;;;;;;;;;;2346:179;;;;;;:::o;805:20::-;;;;;;:::o",
-  "source": "/*\n  This file is part of The Colony Network.\n\n  The Colony Network is free software: you can redistribute it and/or modify\n  it under the terms of the GNU General Public License as published by\n  the Free Software Foundation, either version 3 of the License, or\n  (at your option) any later version.\n\n  The Colony Network is distributed in the hope that it will be useful,\n  but WITHOUT ANY WARRANTY; without even the implied warranty of\n  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n  GNU General Public License for more details.\n\n  You should have received a copy of the GNU General Public License\n  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.\n*/\n\npragma solidity ^0.4.23;\n\nimport \"../lib/dappsys/auth.sol\";\n\n\ncontract TokenAuthority is DSAuthority {\n  address public token;\n  mapping(address => mapping(bytes4 => bool)) authorizations;\n  \n  constructor(\n    address _token,\n    address _colonyNetwork,\n    address _metaColony,\n    address _tokenLocking,\n    address _vesting,\n    address[] miners) public {\n    token = _token;\n    bytes4 transferSig = bytes4(keccak256(\"transfer(address,uint256)\"));\n    bytes4 transferFromSig = bytes4(keccak256(\"transferFrom(address,address,uint256)\"));\n    bytes4 mintSig = bytes4(keccak256(\"mint(uint256)\"));\n\n    authorizations[_colonyNetwork][transferSig] = true;      // Used in IColonyNetworkMining.rewardStakers\n    authorizations[_colonyNetwork][transferFromSig] = true;\n\n    authorizations[_metaColony][transferSig] = true;        // Used in IColony: bootstrapColony, mintTokensForColonyNetwork,\n                                                            // claimPayout and claimRewardPayout\n    authorizations[_metaColony][mintSig] = true;            // Used in IColony.mintTokensForColonyNetwork\n\n    authorizations[_tokenLocking][transferSig] = true;      // Used in ITokenLocking.withdraw\n    authorizations[_tokenLocking][transferFromSig] = true;  // Used in ITokenLocking.deposit\n\n    authorizations[_vesting][transferSig] = true;\n    authorizations[_vesting][transferFromSig] = true;\n\n    // Allow passing in of multiple reputation miner accounts although potentially one will be used in production\n    for (uint i = 0; i < miners.length; i++) {\n      address miner = miners[i];\n      authorizations[miner][transferSig] = true;\n    }\n  }\n\n  function canCall(address src, address dst, bytes4 sig) public view returns (bool) {\n    if (dst != token) {\n      return false;\n    }\n    \n    return authorizations[src][sig];\n  }\n}",
+  "bytecode": "0x608060405234801561001057600080fd5b506040516107313803806107318339810180604052810190808051906020019092919080519060200190929190805190602001909291908051906020019092919080519060200190929190805182019291906020018051906020019092919050505060008060008060008b6000806101000a815481600160a060020a030219169083600160a060020a0316021790555060405180807f7472616e7366657228616464726573732c75696e74323536290000000000000081525060190190506040518091039020945060405180807f7472616e7366657246726f6d28616464726573732c616464726573732c75696e81526020017f743235362900000000000000000000000000000000000000000000000000000081525060250190506040518091039020935060405180807f6d696e742875696e743235362900000000000000000000000000000000000000815250600d0190506040518091039020925060018060008d600160a060020a0316600160a060020a03168152602001908152602001600020600087600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008d600160a060020a0316600160a060020a03168152602001908152602001600020600086600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008c600160a060020a0316600160a060020a03168152602001908152602001600020600087600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008c600160a060020a0316600160a060020a03168152602001908152602001600020600085600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008b600160a060020a0316600160a060020a03168152602001908152602001600020600087600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008b600160a060020a0316600160a060020a03168152602001908152602001600020600086600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008a600160a060020a0316600160a060020a03168152602001908152602001600020600087600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff02191690831515021790555060018060008a600160a060020a0316600160a060020a03168152602001908152602001600020600086600160e060020a031916600160e060020a031916815260200190815260200160002060006101000a81548160ff021916908315150217905550600091505b86518210156104fd57868281518110151561049a57fe5b6020908102909101810151600160a060020a0381166000908152600180845260408083207fffffffff000000000000000000000000000000000000000000000000000000008b168452909452929020805460ff1916831790559201919050610483565b505050600160a060020a0390921660009081526001602081815260408084207fffffffff000000000000000000000000000000000000000000000000000000009096168452949052929020805460ff1916909217909155505050505050506101c78061056a6000396000f30060806040526004361061004b5763ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663b70096138114610050578063fc0c546a146100ba575b600080fd5b34801561005c57600080fd5b506100a673ffffffffffffffffffffffffffffffffffffffff600435811690602435167bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19604435166100f8565b604080519115158252519081900360200190f35b3480156100c657600080fd5b506100cf61017f565b6040805173ffffffffffffffffffffffffffffffffffffffff9092168252519081900360200190f35b6000805473ffffffffffffffffffffffffffffffffffffffff84811691161461012357506000610178565b5073ffffffffffffffffffffffffffffffffffffffff831660009081526001602090815260408083207bffffffffffffffffffffffffffffffffffffffffffffffffffffffff198516845290915290205460ff165b9392505050565b60005473ffffffffffffffffffffffffffffffffffffffff16815600a165627a7a72305820c84ca178abd404fbdeaaa262300ed87649fc3eee134c9d94972cb81e42efb5500029",
+  "deployedBytecode": "0x60806040526004361061004b5763ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663b70096138114610050578063fc0c546a146100ba575b600080fd5b34801561005c57600080fd5b506100a673ffffffffffffffffffffffffffffffffffffffff600435811690602435167bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19604435166100f8565b604080519115158252519081900360200190f35b3480156100c657600080fd5b506100cf61017f565b6040805173ffffffffffffffffffffffffffffffffffffffff9092168252519081900360200190f35b6000805473ffffffffffffffffffffffffffffffffffffffff84811691161461012357506000610178565b5073ffffffffffffffffffffffffffffffffffffffff831660009081526001602090815260408083207bffffffffffffffffffffffffffffffffffffffffffffffffffffffff198516845290915290205460ff165b9392505050565b60005473ffffffffffffffffffffffffffffffffffffffff16815600a165627a7a72305820c84ca178abd404fbdeaaa262300ed87649fc3eee134c9d94972cb81e42efb5500029",
+  "sourceMap": "762:1840:3:-;;;892:1529;8:9:-1;5:2;;;30:1;27;20:12;5:2;892:1529:3;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1106:18;1179:22;1268:14;2235:6;2279:13;1094:6;1086:5;;:14;;;;;-1:-1:-1;;;;;1086:14:3;;;;;-1:-1:-1;;;;;1086:14:3;;;;;;1134:38;;;;;;;;;;;;;;;;;;;1106:67;;1211:50;;;;;;;;;;;;;;;;;;;;;;;;1179:83;;1292:26;;;;;;;;;;;;;;;;;;;1268:51;;1372:4;1326:14;:30;1341:14;-1:-1:-1;;;;;1326:30:3;-1:-1:-1;;;;;1326:30:3;;;;;;;;;;;;:43;1357:11;-1:-1:-1;;;;;1326:43:3;;-1:-1:-1;;;;;1326:43:3;;;;;;;;;;;;;;:50;;;;;;;;;;;;;;;;;;1483:4;1433:14;:30;1448:14;-1:-1:-1;;;;;1433:30:3;-1:-1:-1;;;;;1433:30:3;;;;;;;;;;;;:47;1464:15;-1:-1:-1;;;;;1433:47:3;;-1:-1:-1;;;;;1433:47:3;;;;;;;;;;;;;;:54;;;;;;;;;;;;;;;;;;1537:4;1494:14;:27;1509:11;-1:-1:-1;;;;;1494:27:3;-1:-1:-1;;;;;1494:27:3;;;;;;;;;;;;:40;1522:11;-1:-1:-1;;;;;1494:40:3;;-1:-1:-1;;;;;1494:40:3;;;;;;;;;;;;;;:47;;;;;;;;;;;;;;;;;;1755:4;1716:14;:27;1731:11;-1:-1:-1;;;;;1716:27:3;-1:-1:-1;;;;;1716:27:3;;;;;;;;;;;;:36;1744:7;-1:-1:-1;;;;;1716:36:3;;-1:-1:-1;;;;;1716:36:3;;;;;;;;;;;;;;:43;;;;;;;;;;;;;;;;;;1868:4;1823:14;:29;1838:13;-1:-1:-1;;;;;1823:29:3;-1:-1:-1;;;;;1823:29:3;;;;;;;;;;;;:42;1853:11;-1:-1:-1;;;;;1823:42:3;;-1:-1:-1;;;;;1823:42:3;;;;;;;;;;;;;;:49;;;;;;;;;;;;;;;;;;1966:4;1917:14;:29;1932:13;-1:-1:-1;;;;;1917:29:3;-1:-1:-1;;;;;1917:29:3;;;;;;;;;;;;:46;1947:15;-1:-1:-1;;;;;1917:46:3;;-1:-1:-1;;;;;1917:46:3;;;;;;;;;;;;;;:53;;;;;;;;;;;;;;;;;;2051:4;2011:14;:24;2026:8;-1:-1:-1;;;;;2011:24:3;-1:-1:-1;;;;;2011:24:3;;;;;;;;;;;;:37;2036:11;-1:-1:-1;;;;;2011:37:3;;-1:-1:-1;;;;;2011:37:3;;;;;;;;;;;;;;:44;;;;;;;;;;;;;;;;;;2105:4;2061:14;:24;2076:8;-1:-1:-1;;;;;2061:24:3;-1:-1:-1;;;;;2061:24:3;;;;;;;;;;;;:41;2086:15;-1:-1:-1;;;;;2061:41:3;;-1:-1:-1;;;;;2061:41:3;;;;;;;;;;;;;;:48;;;;;;;;;;;;;;;;;;2244:1;2235:10;;2230:130;2251:6;:13;2247:1;:17;2230:130;;;2295:6;2302:1;2295:9;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;2312:21:3;;;;;;2349:4;2312:21;;;;;;;:34;;;;;;;;;;;:41;;-1:-1:-1;;2312:41:3;;;;;2266:3;;;2295:9;-1:-1:-1;2230:130:3;;;-1:-1:-1;;;;;;;;2366:26:3;;;;;;;2412:4;2366:26;;;;;;;;:43;;;;;;;;;;;;:50;;-1:-1:-1;;2366:50:3;;;;;;;-1:-1:-1;;;;;;;762:1840:3;;;;;;",
+  "deployedSourceMap": "762:1840:3:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;2425:175;;8:9:-1;5:2;;;30:1;27;20:12;5:2;-1:-1;2425:175:3;;;;;;;;;;-1:-1:-1;;2425:175:3;;;;;;;;;;;;;;;;;;;;;;;805:20;;8:9:-1;5:2;;;30:1;27;20:12;5:2;805:20:3;;;;;;;;;;;;;;;;;;;;;;;2425:175;2501:4;2524:5;;;2517:12;;;2524:5;;2517:12;2513:45;;-1:-1:-1;2546:5:3;2539:12;;2513:45;-1:-1:-1;2571:19:3;;;;;;;:14;:19;;;;;;;;-1:-1:-1;;2571:24:3;;;;;;;;;;;;2425:175;;;;;;:::o;805:20::-;;;;;;:::o",
+  "source": "/*\n  This file is part of The Colony Network.\n\n  The Colony Network is free software: you can redistribute it and/or modify\n  it under the terms of the GNU General Public License as published by\n  the Free Software Foundation, either version 3 of the License, or\n  (at your option) any later version.\n\n  The Colony Network is distributed in the hope that it will be useful,\n  but WITHOUT ANY WARRANTY; without even the implied warranty of\n  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n  GNU General Public License for more details.\n\n  You should have received a copy of the GNU General Public License\n  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.\n*/\n\npragma solidity ^0.4.23;\n\nimport \"../lib/dappsys/auth.sol\";\n\n\ncontract TokenAuthority is DSAuthority {\n  address public token;\n  mapping(address => mapping(bytes4 => bool)) authorizations;\n\n  constructor(\n    address _token,\n    address _colonyNetwork,\n    address _metaColony,\n    address _tokenLocking,\n    address _vesting,\n    address[] miners,\n    address _regulator) public {\n    token = _token;\n    bytes4 transferSig = bytes4(keccak256(\"transfer(address,uint256)\"));\n    bytes4 transferFromSig = bytes4(keccak256(\"transferFrom(address,address,uint256)\"));\n    bytes4 mintSig = bytes4(keccak256(\"mint(uint256)\"));\n\n    authorizations[_colonyNetwork][transferSig] = true;      // Used in IColonyNetworkMining.rewardStakers\n    authorizations[_colonyNetwork][transferFromSig] = true;\n\n    authorizations[_metaColony][transferSig] = true;        // Used in IColony: bootstrapColony, mintTokensForColonyNetwork,\n                                                            // claimPayout and claimRewardPayout\n    authorizations[_metaColony][mintSig] = true;            // Used in IColony.mintTokensForColonyNetwork\n\n    authorizations[_tokenLocking][transferSig] = true;      // Used in ITokenLocking.withdraw\n    authorizations[_tokenLocking][transferFromSig] = true;  // Used in ITokenLocking.deposit\n\n    authorizations[_vesting][transferSig] = true;\n    authorizations[_vesting][transferFromSig] = true;\n\n    // Allow passing in of multiple reputation miner accounts although potentially one will be used in production\n    for (uint i = 0; i < miners.length; i++) {\n      address miner = miners[i];\n      authorizations[miner][transferSig] = true;\n    }\n\n    authorizations[_regulator][transferFromSig] = true;\n  }\n\n  function canCall(address src, address dst, bytes4 sig) public view returns (bool) {\n    if (dst != token) {\n      return false;\n    }\n\n    return authorizations[src][sig];\n  }\n}\n",
   "sourcePath": "/Users/Elena/colonyToken/contracts/TokenAuthority.sol",
   "ast": {
     "absolutePath": "/Users/Elena/colonyToken/contracts/TokenAuthority.sol",
     "exportedSymbols": {
       "TokenAuthority": [
-        421
+        431
       ]
     },
-    "id": 422,
+    "id": 432,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -106,8 +110,8 @@
         "file": "../lib/dappsys/auth.sol",
         "id": 249,
         "nodeType": "ImportDirective",
-        "scope": 422,
-        "sourceUnit": 2015,
+        "scope": 432,
+        "sourceUnit": 2206,
         "src": "726:33:3",
         "symbolAliases": [],
         "unitAlias": ""
@@ -121,10 +125,10 @@
               "id": 250,
               "name": "DSAuthority",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 1896,
+              "referencedDeclaration": 2087,
               "src": "789:11:3",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_DSAuthority_$1896",
+                "typeIdentifier": "t_contract$_DSAuthority_$2087",
                 "typeString": "contract DSAuthority"
               }
             },
@@ -134,15 +138,15 @@
           }
         ],
         "contractDependencies": [
-          1896
+          2087
         ],
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 421,
+        "id": 431,
         "linearizedBaseContracts": [
-          421,
-          1896
+          431,
+          2087
         ],
         "name": "TokenAuthority",
         "nodeType": "ContractDefinition",
@@ -152,7 +156,7 @@
             "id": 253,
             "name": "token",
             "nodeType": "VariableDeclaration",
-            "scope": 421,
+            "scope": 431,
             "src": "805:20:3",
             "stateVariable": true,
             "storageLocation": "default",
@@ -178,7 +182,7 @@
             "id": 259,
             "name": "authorizations",
             "nodeType": "VariableDeclaration",
-            "scope": 421,
+            "scope": 431,
             "src": "829:58:3",
             "stateVariable": true,
             "storageLocation": "default",
@@ -239,26 +243,26 @@
           },
           {
             "body": {
-              "id": 394,
+              "id": 404,
               "nodeType": "Block",
-              "src": "1058:1284:3",
+              "src": "1080:1341:3",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 277,
+                    "id": 279,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 275,
+                      "id": 277,
                       "name": "token",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 253,
-                      "src": "1064:5:3",
+                      "src": "1086:5:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -268,39 +272,39 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 276,
+                      "id": 278,
                       "name": "_token",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 261,
-                      "src": "1072:6:3",
+                      "src": "1094:6:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "1064:14:3",
+                    "src": "1086:14:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     }
                   },
-                  "id": 278,
+                  "id": 280,
                   "nodeType": "ExpressionStatement",
-                  "src": "1064:14:3"
+                  "src": "1086:14:3"
                 },
                 {
                   "assignments": [
-                    280
+                    282
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 280,
+                      "id": 282,
                       "name": "transferSig",
                       "nodeType": "VariableDeclaration",
-                      "scope": 395,
-                      "src": "1084:18:3",
+                      "scope": 405,
+                      "src": "1106:18:3",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -308,10 +312,10 @@
                         "typeString": "bytes4"
                       },
                       "typeName": {
-                        "id": 279,
+                        "id": 281,
                         "name": "bytes4",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1084:6:3",
+                        "src": "1106:6:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -321,7 +325,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 286,
+                  "id": 288,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -331,14 +335,14 @@
                           {
                             "argumentTypes": null,
                             "hexValue": "7472616e7366657228616464726573732c75696e7432353629",
-                            "id": 283,
+                            "id": 285,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "string",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "1122:27:3",
+                            "src": "1144:27:3",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_stringliteral_a9059cbb2ab09eb219583f4a59a5d0623ade346d962bcd4e46b11da047c9049b",
@@ -354,18 +358,18 @@
                               "typeString": "literal_string \"transfer(address,uint256)\""
                             }
                           ],
-                          "id": 282,
+                          "id": 284,
                           "name": "keccak256",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2580,
-                          "src": "1112:9:3",
+                          "referencedDeclaration": 2771,
+                          "src": "1134:9:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_sha3_pure$__$returns$_t_bytes32_$",
                             "typeString": "function () pure returns (bytes32)"
                           }
                         },
-                        "id": 284,
+                        "id": 286,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -373,7 +377,7 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "1112:38:3",
+                        "src": "1134:38:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes32",
                           "typeString": "bytes32"
@@ -387,20 +391,20 @@
                           "typeString": "bytes32"
                         }
                       ],
-                      "id": 281,
+                      "id": 283,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "lValueRequested": false,
                       "nodeType": "ElementaryTypeNameExpression",
-                      "src": "1105:6:3",
+                      "src": "1127:6:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_type$_t_bytes4_$",
                         "typeString": "type(bytes4)"
                       },
                       "typeName": "bytes4"
                     },
-                    "id": 285,
+                    "id": 287,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
@@ -408,27 +412,27 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1105:46:3",
+                    "src": "1127:46:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes4",
                       "typeString": "bytes4"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1084:67:3"
+                  "src": "1106:67:3"
                 },
                 {
                   "assignments": [
-                    288
+                    290
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 288,
+                      "id": 290,
                       "name": "transferFromSig",
                       "nodeType": "VariableDeclaration",
-                      "scope": 395,
-                      "src": "1157:22:3",
+                      "scope": 405,
+                      "src": "1179:22:3",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -436,10 +440,10 @@
                         "typeString": "bytes4"
                       },
                       "typeName": {
-                        "id": 287,
+                        "id": 289,
                         "name": "bytes4",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1157:6:3",
+                        "src": "1179:6:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -449,7 +453,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 294,
+                  "id": 296,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -459,14 +463,14 @@
                           {
                             "argumentTypes": null,
                             "hexValue": "7472616e7366657246726f6d28616464726573732c616464726573732c75696e7432353629",
-                            "id": 291,
+                            "id": 293,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "string",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "1199:39:3",
+                            "src": "1221:39:3",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_stringliteral_23b872dd7302113369cda2901243429419bec145408fa8b352b3dd92b66c680b",
@@ -482,18 +486,18 @@
                               "typeString": "literal_string \"transferFrom(address,address,uint256)\""
                             }
                           ],
-                          "id": 290,
+                          "id": 292,
                           "name": "keccak256",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2580,
-                          "src": "1189:9:3",
+                          "referencedDeclaration": 2771,
+                          "src": "1211:9:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_sha3_pure$__$returns$_t_bytes32_$",
                             "typeString": "function () pure returns (bytes32)"
                           }
                         },
-                        "id": 292,
+                        "id": 294,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -501,7 +505,7 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "1189:50:3",
+                        "src": "1211:50:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes32",
                           "typeString": "bytes32"
@@ -515,20 +519,20 @@
                           "typeString": "bytes32"
                         }
                       ],
-                      "id": 289,
+                      "id": 291,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "lValueRequested": false,
                       "nodeType": "ElementaryTypeNameExpression",
-                      "src": "1182:6:3",
+                      "src": "1204:6:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_type$_t_bytes4_$",
                         "typeString": "type(bytes4)"
                       },
                       "typeName": "bytes4"
                     },
-                    "id": 293,
+                    "id": 295,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
@@ -536,27 +540,27 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1182:58:3",
+                    "src": "1204:58:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes4",
                       "typeString": "bytes4"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1157:83:3"
+                  "src": "1179:83:3"
                 },
                 {
                   "assignments": [
-                    296
+                    298
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 296,
+                      "id": 298,
                       "name": "mintSig",
                       "nodeType": "VariableDeclaration",
-                      "scope": 395,
-                      "src": "1246:14:3",
+                      "scope": 405,
+                      "src": "1268:14:3",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -564,10 +568,10 @@
                         "typeString": "bytes4"
                       },
                       "typeName": {
-                        "id": 295,
+                        "id": 297,
                         "name": "bytes4",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1246:6:3",
+                        "src": "1268:6:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -577,7 +581,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 302,
+                  "id": 304,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -587,14 +591,14 @@
                           {
                             "argumentTypes": null,
                             "hexValue": "6d696e742875696e7432353629",
-                            "id": 299,
+                            "id": 301,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "string",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "1280:15:3",
+                            "src": "1302:15:3",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_stringliteral_a0712d680358d64f694230b7cc0b277c73686bdf768385d55cd7c547d0ffd30e",
@@ -610,18 +614,18 @@
                               "typeString": "literal_string \"mint(uint256)\""
                             }
                           ],
-                          "id": 298,
+                          "id": 300,
                           "name": "keccak256",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2580,
-                          "src": "1270:9:3",
+                          "referencedDeclaration": 2771,
+                          "src": "1292:9:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_sha3_pure$__$returns$_t_bytes32_$",
                             "typeString": "function () pure returns (bytes32)"
                           }
                         },
-                        "id": 300,
+                        "id": 302,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -629,7 +633,7 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "1270:26:3",
+                        "src": "1292:26:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes32",
                           "typeString": "bytes32"
@@ -643,20 +647,20 @@
                           "typeString": "bytes32"
                         }
                       ],
-                      "id": 297,
+                      "id": 299,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "lValueRequested": false,
                       "nodeType": "ElementaryTypeNameExpression",
-                      "src": "1263:6:3",
+                      "src": "1285:6:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_type$_t_bytes4_$",
                         "typeString": "type(bytes4)"
                       },
                       "typeName": "bytes4"
                     },
-                    "id": 301,
+                    "id": 303,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
@@ -664,19 +668,19 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1263:34:3",
+                    "src": "1285:34:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes4",
                       "typeString": "bytes4"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1246:51:3"
+                  "src": "1268:51:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 309,
+                    "id": 311,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -687,26 +691,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 303,
+                          "id": 305,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1304:14:3",
+                          "src": "1326:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 306,
+                        "id": 308,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 304,
+                          "id": 306,
                           "name": "_colonyNetwork",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 263,
-                          "src": "1319:14:3",
+                          "src": "1341:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -717,21 +721,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1304:30:3",
+                        "src": "1326:30:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 307,
+                      "id": 309,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 305,
+                        "id": 307,
                         "name": "transferSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 280,
-                        "src": "1335:11:3",
+                        "referencedDeclaration": 282,
+                        "src": "1357:11:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -742,7 +746,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1304:43:3",
+                      "src": "1326:43:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -753,14 +757,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 308,
+                      "id": 310,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1350:4:3",
+                      "src": "1372:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -768,20 +772,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1304:50:3",
+                    "src": "1326:50:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 310,
+                  "id": 312,
                   "nodeType": "ExpressionStatement",
-                  "src": "1304:50:3"
+                  "src": "1326:50:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 317,
+                    "id": 319,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -792,26 +796,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 311,
+                          "id": 313,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1411:14:3",
+                          "src": "1433:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 314,
+                        "id": 316,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 312,
+                          "id": 314,
                           "name": "_colonyNetwork",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 263,
-                          "src": "1426:14:3",
+                          "src": "1448:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -822,21 +826,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1411:30:3",
+                        "src": "1433:30:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 315,
+                      "id": 317,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 313,
+                        "id": 315,
                         "name": "transferFromSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 288,
-                        "src": "1442:15:3",
+                        "referencedDeclaration": 290,
+                        "src": "1464:15:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -847,7 +851,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1411:47:3",
+                      "src": "1433:47:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -858,14 +862,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 316,
+                      "id": 318,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1461:4:3",
+                      "src": "1483:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -873,20 +877,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1411:54:3",
+                    "src": "1433:54:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 318,
+                  "id": 320,
                   "nodeType": "ExpressionStatement",
-                  "src": "1411:54:3"
+                  "src": "1433:54:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 325,
+                    "id": 327,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -897,26 +901,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 319,
+                          "id": 321,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1472:14:3",
+                          "src": "1494:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 322,
+                        "id": 324,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 320,
+                          "id": 322,
                           "name": "_metaColony",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 265,
-                          "src": "1487:11:3",
+                          "src": "1509:11:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -927,21 +931,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1472:27:3",
+                        "src": "1494:27:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 323,
+                      "id": 325,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 321,
+                        "id": 323,
                         "name": "transferSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 280,
-                        "src": "1500:11:3",
+                        "referencedDeclaration": 282,
+                        "src": "1522:11:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -952,7 +956,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1472:40:3",
+                      "src": "1494:40:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -963,14 +967,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 324,
+                      "id": 326,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1515:4:3",
+                      "src": "1537:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -978,20 +982,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1472:47:3",
+                    "src": "1494:47:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 326,
+                  "id": 328,
                   "nodeType": "ExpressionStatement",
-                  "src": "1472:47:3"
+                  "src": "1494:47:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 333,
+                    "id": 335,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1002,26 +1006,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 327,
+                          "id": 329,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1694:14:3",
+                          "src": "1716:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 330,
+                        "id": 332,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 328,
+                          "id": 330,
                           "name": "_metaColony",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 265,
-                          "src": "1709:11:3",
+                          "src": "1731:11:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1032,21 +1036,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1694:27:3",
+                        "src": "1716:27:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 331,
+                      "id": 333,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 329,
+                        "id": 331,
                         "name": "mintSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 296,
-                        "src": "1722:7:3",
+                        "referencedDeclaration": 298,
+                        "src": "1744:7:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -1057,7 +1061,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1694:36:3",
+                      "src": "1716:36:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -1068,14 +1072,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 332,
+                      "id": 334,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1733:4:3",
+                      "src": "1755:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -1083,20 +1087,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1694:43:3",
+                    "src": "1716:43:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 334,
+                  "id": 336,
                   "nodeType": "ExpressionStatement",
-                  "src": "1694:43:3"
+                  "src": "1716:43:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 341,
+                    "id": 343,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1107,26 +1111,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 335,
+                          "id": 337,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1801:14:3",
+                          "src": "1823:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 338,
+                        "id": 340,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 336,
+                          "id": 338,
                           "name": "_tokenLocking",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 267,
-                          "src": "1816:13:3",
+                          "src": "1838:13:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1137,21 +1141,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1801:29:3",
+                        "src": "1823:29:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 339,
+                      "id": 341,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 337,
+                        "id": 339,
                         "name": "transferSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 280,
-                        "src": "1831:11:3",
+                        "referencedDeclaration": 282,
+                        "src": "1853:11:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -1162,7 +1166,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1801:42:3",
+                      "src": "1823:42:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -1173,14 +1177,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 340,
+                      "id": 342,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1846:4:3",
+                      "src": "1868:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -1188,20 +1192,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1801:49:3",
+                    "src": "1823:49:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 342,
+                  "id": 344,
                   "nodeType": "ExpressionStatement",
-                  "src": "1801:49:3"
+                  "src": "1823:49:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 349,
+                    "id": 351,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1212,26 +1216,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 343,
+                          "id": 345,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1895:14:3",
+                          "src": "1917:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 346,
+                        "id": 348,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 344,
+                          "id": 346,
                           "name": "_tokenLocking",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 267,
-                          "src": "1910:13:3",
+                          "src": "1932:13:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1242,21 +1246,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1895:29:3",
+                        "src": "1917:29:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 347,
+                      "id": 349,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 345,
+                        "id": 347,
                         "name": "transferFromSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 288,
-                        "src": "1925:15:3",
+                        "referencedDeclaration": 290,
+                        "src": "1947:15:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -1267,7 +1271,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1895:46:3",
+                      "src": "1917:46:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -1278,14 +1282,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 348,
+                      "id": 350,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1944:4:3",
+                      "src": "1966:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -1293,20 +1297,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1895:53:3",
+                    "src": "1917:53:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 350,
+                  "id": 352,
                   "nodeType": "ExpressionStatement",
-                  "src": "1895:53:3"
+                  "src": "1917:53:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 357,
+                    "id": 359,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1317,26 +1321,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 351,
+                          "id": 353,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1989:14:3",
+                          "src": "2011:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 354,
+                        "id": 356,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 352,
+                          "id": 354,
                           "name": "_vesting",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 269,
-                          "src": "2004:8:3",
+                          "src": "2026:8:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1347,21 +1351,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1989:24:3",
+                        "src": "2011:24:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 355,
+                      "id": 357,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 353,
+                        "id": 355,
                         "name": "transferSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 280,
-                        "src": "2014:11:3",
+                        "referencedDeclaration": 282,
+                        "src": "2036:11:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -1372,7 +1376,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1989:37:3",
+                      "src": "2011:37:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -1383,14 +1387,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 356,
+                      "id": 358,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "2029:4:3",
+                      "src": "2051:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -1398,20 +1402,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1989:44:3",
+                    "src": "2011:44:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 358,
+                  "id": 360,
                   "nodeType": "ExpressionStatement",
-                  "src": "1989:44:3"
+                  "src": "2011:44:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 365,
+                    "id": 367,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1422,26 +1426,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 359,
+                          "id": 361,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "2039:14:3",
+                          "src": "2061:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 362,
+                        "id": 364,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 360,
+                          "id": 362,
                           "name": "_vesting",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 269,
-                          "src": "2054:8:3",
+                          "src": "2076:8:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1452,21 +1456,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "2039:24:3",
+                        "src": "2061:24:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 363,
+                      "id": 365,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 361,
+                        "id": 363,
                         "name": "transferFromSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 288,
-                        "src": "2064:15:3",
+                        "referencedDeclaration": 290,
+                        "src": "2086:15:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -1477,7 +1481,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "2039:41:3",
+                      "src": "2061:41:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -1488,14 +1492,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 364,
+                      "id": 366,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "2083:4:3",
+                      "src": "2105:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -1503,34 +1507,34 @@
                       },
                       "value": "true"
                     },
-                    "src": "2039:48:3",
+                    "src": "2061:48:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 366,
+                  "id": 368,
                   "nodeType": "ExpressionStatement",
-                  "src": "2039:48:3"
+                  "src": "2061:48:3"
                 },
                 {
                   "body": {
-                    "id": 392,
+                    "id": 394,
                     "nodeType": "Block",
-                    "src": "2249:89:3",
+                    "src": "2271:89:3",
                     "statements": [
                       {
                         "assignments": [
-                          379
+                          381
                         ],
                         "declarations": [
                           {
                             "constant": false,
-                            "id": 379,
+                            "id": 381,
                             "name": "miner",
                             "nodeType": "VariableDeclaration",
-                            "scope": 395,
-                            "src": "2257:13:3",
+                            "scope": 405,
+                            "src": "2279:13:3",
                             "stateVariable": false,
                             "storageLocation": "default",
                             "typeDescriptions": {
@@ -1538,10 +1542,10 @@
                               "typeString": "address"
                             },
                             "typeName": {
-                              "id": 378,
+                              "id": 380,
                               "name": "address",
                               "nodeType": "ElementaryTypeName",
-                              "src": "2257:7:3",
+                              "src": "2279:7:3",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
@@ -1551,31 +1555,31 @@
                             "visibility": "internal"
                           }
                         ],
-                        "id": 383,
+                        "id": 385,
                         "initialValue": {
                           "argumentTypes": null,
                           "baseExpression": {
                             "argumentTypes": null,
-                            "id": 380,
+                            "id": 382,
                             "name": "miners",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 272,
-                            "src": "2273:6:3",
+                            "src": "2295:6:3",
                             "typeDescriptions": {
                               "typeIdentifier": "t_array$_t_address_$dyn_memory_ptr",
                               "typeString": "address[] memory"
                             }
                           },
-                          "id": 382,
+                          "id": 384,
                           "indexExpression": {
                             "argumentTypes": null,
-                            "id": 381,
+                            "id": 383,
                             "name": "i",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 368,
-                            "src": "2280:1:3",
+                            "referencedDeclaration": 370,
+                            "src": "2302:1:3",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -1586,19 +1590,19 @@
                           "isPure": false,
                           "lValueRequested": false,
                           "nodeType": "IndexAccess",
-                          "src": "2273:9:3",
+                          "src": "2295:9:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
                         "nodeType": "VariableDeclarationStatement",
-                        "src": "2257:25:3"
+                        "src": "2279:25:3"
                       },
                       {
                         "expression": {
                           "argumentTypes": null,
-                          "id": 390,
+                          "id": 392,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -1609,26 +1613,26 @@
                               "argumentTypes": null,
                               "baseExpression": {
                                 "argumentTypes": null,
-                                "id": 384,
+                                "id": 386,
                                 "name": "authorizations",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 259,
-                                "src": "2290:14:3",
+                                "src": "2312:14:3",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                                   "typeString": "mapping(address => mapping(bytes4 => bool))"
                                 }
                               },
-                              "id": 387,
+                              "id": 389,
                               "indexExpression": {
                                 "argumentTypes": null,
-                                "id": 385,
+                                "id": 387,
                                 "name": "miner",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 379,
-                                "src": "2305:5:3",
+                                "referencedDeclaration": 381,
+                                "src": "2327:5:3",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
                                   "typeString": "address"
@@ -1639,21 +1643,21 @@
                               "isPure": false,
                               "lValueRequested": false,
                               "nodeType": "IndexAccess",
-                              "src": "2290:21:3",
+                              "src": "2312:21:3",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                                 "typeString": "mapping(bytes4 => bool)"
                               }
                             },
-                            "id": 388,
+                            "id": 390,
                             "indexExpression": {
                               "argumentTypes": null,
-                              "id": 386,
+                              "id": 388,
                               "name": "transferSig",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 280,
-                              "src": "2312:11:3",
+                              "referencedDeclaration": 282,
+                              "src": "2334:11:3",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_bytes4",
                                 "typeString": "bytes4"
@@ -1664,7 +1668,7 @@
                             "isPure": false,
                             "lValueRequested": true,
                             "nodeType": "IndexAccess",
-                            "src": "2290:34:3",
+                            "src": "2312:34:3",
                             "typeDescriptions": {
                               "typeIdentifier": "t_bool",
                               "typeString": "bool"
@@ -1675,14 +1679,14 @@
                           "rightHandSide": {
                             "argumentTypes": null,
                             "hexValue": "74727565",
-                            "id": 389,
+                            "id": 391,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "bool",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "2327:4:3",
+                            "src": "2349:4:3",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_bool",
@@ -1690,15 +1694,15 @@
                             },
                             "value": "true"
                           },
-                          "src": "2290:41:3",
+                          "src": "2312:41:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "id": 391,
+                        "id": 393,
                         "nodeType": "ExpressionStatement",
-                        "src": "2290:41:3"
+                        "src": "2312:41:3"
                       }
                     ]
                   },
@@ -1708,19 +1712,19 @@
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
                     },
-                    "id": 374,
+                    "id": 376,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftExpression": {
                       "argumentTypes": null,
-                      "id": 371,
+                      "id": 373,
                       "name": "i",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 368,
-                      "src": "2225:1:3",
+                      "referencedDeclaration": 370,
+                      "src": "2247:1:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -1732,18 +1736,18 @@
                       "argumentTypes": null,
                       "expression": {
                         "argumentTypes": null,
-                        "id": 372,
+                        "id": 374,
                         "name": "miners",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 272,
-                        "src": "2229:6:3",
+                        "src": "2251:6:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_array$_t_address_$dyn_memory_ptr",
                           "typeString": "address[] memory"
                         }
                       },
-                      "id": 373,
+                      "id": 375,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -1751,31 +1755,31 @@
                       "memberName": "length",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "2229:13:3",
+                      "src": "2251:13:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       }
                     },
-                    "src": "2225:17:3",
+                    "src": "2247:17:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 393,
+                  "id": 395,
                   "initializationExpression": {
                     "assignments": [
-                      368
+                      370
                     ],
                     "declarations": [
                       {
                         "constant": false,
-                        "id": 368,
+                        "id": 370,
                         "name": "i",
                         "nodeType": "VariableDeclaration",
-                        "scope": 395,
-                        "src": "2213:6:3",
+                        "scope": 405,
+                        "src": "2235:6:3",
                         "stateVariable": false,
                         "storageLocation": "default",
                         "typeDescriptions": {
@@ -1783,10 +1787,10 @@
                           "typeString": "uint256"
                         },
                         "typeName": {
-                          "id": 367,
+                          "id": 369,
                           "name": "uint",
                           "nodeType": "ElementaryTypeName",
-                          "src": "2213:4:3",
+                          "src": "2235:4:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -1796,18 +1800,18 @@
                         "visibility": "internal"
                       }
                     ],
-                    "id": 370,
+                    "id": 372,
                     "initialValue": {
                       "argumentTypes": null,
                       "hexValue": "30",
-                      "id": 369,
+                      "id": 371,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "number",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "2222:1:3",
+                      "src": "2244:1:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_rational_0_by_1",
@@ -1816,12 +1820,12 @@
                       "value": "0"
                     },
                     "nodeType": "VariableDeclarationStatement",
-                    "src": "2213:10:3"
+                    "src": "2235:10:3"
                   },
                   "loopExpression": {
                     "expression": {
                       "argumentTypes": null,
-                      "id": 376,
+                      "id": 378,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -1829,15 +1833,15 @@
                       "nodeType": "UnaryOperation",
                       "operator": "++",
                       "prefix": false,
-                      "src": "2244:3:3",
+                      "src": "2266:3:3",
                       "subExpression": {
                         "argumentTypes": null,
-                        "id": 375,
+                        "id": 377,
                         "name": "i",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 368,
-                        "src": "2244:1:3",
+                        "referencedDeclaration": 370,
+                        "src": "2266:1:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -1848,17 +1852,122 @@
                         "typeString": "uint256"
                       }
                     },
-                    "id": 377,
+                    "id": 379,
                     "nodeType": "ExpressionStatement",
-                    "src": "2244:3:3"
+                    "src": "2266:3:3"
                   },
                   "nodeType": "ForStatement",
-                  "src": "2208:130:3"
+                  "src": "2230:130:3"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 402,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "baseExpression": {
+                        "argumentTypes": null,
+                        "baseExpression": {
+                          "argumentTypes": null,
+                          "id": 396,
+                          "name": "authorizations",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 259,
+                          "src": "2366:14:3",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
+                            "typeString": "mapping(address => mapping(bytes4 => bool))"
+                          }
+                        },
+                        "id": 399,
+                        "indexExpression": {
+                          "argumentTypes": null,
+                          "id": 397,
+                          "name": "_regulator",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 274,
+                          "src": "2381:10:3",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "IndexAccess",
+                        "src": "2366:26:3",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
+                          "typeString": "mapping(bytes4 => bool)"
+                        }
+                      },
+                      "id": 400,
+                      "indexExpression": {
+                        "argumentTypes": null,
+                        "id": 398,
+                        "name": "transferFromSig",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 290,
+                        "src": "2393:15:3",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes4",
+                          "typeString": "bytes4"
+                        }
+                      },
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "nodeType": "IndexAccess",
+                      "src": "2366:43:3",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "hexValue": "74727565",
+                      "id": 401,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "bool",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "2412:4:3",
+                      "subdenomination": null,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      },
+                      "value": "true"
+                    },
+                    "src": "2366:50:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "id": 403,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2366:50:3"
                 }
               ]
             },
             "documentation": null,
-            "id": 395,
+            "id": 405,
             "implemented": true,
             "isConstructor": true,
             "isDeclaredConst": false,
@@ -1866,7 +1975,7 @@
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 273,
+              "id": 275,
               "nodeType": "ParameterList",
               "parameters": [
                 {
@@ -1874,8 +1983,8 @@
                   "id": 261,
                   "name": "_token",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "911:14:3",
+                  "scope": 405,
+                  "src": "909:14:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1886,7 +1995,7 @@
                     "id": 260,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "911:7:3",
+                    "src": "909:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -1900,8 +2009,8 @@
                   "id": 263,
                   "name": "_colonyNetwork",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "931:22:3",
+                  "scope": 405,
+                  "src": "929:22:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1912,7 +2021,7 @@
                     "id": 262,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "931:7:3",
+                    "src": "929:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -1926,8 +2035,8 @@
                   "id": 265,
                   "name": "_metaColony",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "959:19:3",
+                  "scope": 405,
+                  "src": "957:19:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1938,7 +2047,7 @@
                     "id": 264,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "959:7:3",
+                    "src": "957:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -1952,8 +2061,8 @@
                   "id": 267,
                   "name": "_tokenLocking",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "984:21:3",
+                  "scope": 405,
+                  "src": "982:21:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1964,7 +2073,7 @@
                     "id": 266,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "984:7:3",
+                    "src": "982:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -1978,8 +2087,8 @@
                   "id": 269,
                   "name": "_vesting",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "1011:16:3",
+                  "scope": 405,
+                  "src": "1009:16:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1990,7 +2099,7 @@
                     "id": 268,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1011:7:3",
+                    "src": "1009:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -2004,8 +2113,8 @@
                   "id": 272,
                   "name": "miners",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "1033:16:3",
+                  "scope": 405,
+                  "src": "1031:16:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2017,7 +2126,7 @@
                       "id": 270,
                       "name": "address",
                       "nodeType": "ElementaryTypeName",
-                      "src": "1033:7:3",
+                      "src": "1031:7:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -2026,7 +2135,7 @@
                     "id": 271,
                     "length": null,
                     "nodeType": "ArrayTypeName",
-                    "src": "1033:9:3",
+                    "src": "1031:9:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_array$_t_address_$dyn_storage_ptr",
                       "typeString": "address[]"
@@ -2034,28 +2143,54 @@
                   },
                   "value": null,
                   "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 274,
+                  "name": "_regulator",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 405,
+                  "src": "1053:18:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 273,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1053:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
                 }
               ],
-              "src": "905:145:3"
+              "src": "903:169:3"
             },
             "payable": false,
             "returnParameters": {
-              "id": 274,
+              "id": 276,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1058:0:3"
+              "src": "1080:0:3"
             },
-            "scope": 421,
-            "src": "894:1448:3",
+            "scope": 431,
+            "src": "892:1529:3",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           },
           {
             "body": {
-              "id": 419,
+              "id": 429,
               "nodeType": "Block",
-              "src": "2428:97:3",
+              "src": "2507:93:3",
               "statements": [
                 {
                   "condition": {
@@ -2064,19 +2199,19 @@
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     },
-                    "id": 408,
+                    "id": 418,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftExpression": {
                       "argumentTypes": null,
-                      "id": 406,
+                      "id": 416,
                       "name": "dst",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 399,
-                      "src": "2438:3:3",
+                      "referencedDeclaration": 409,
+                      "src": "2517:3:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -2086,44 +2221,44 @@
                     "operator": "!=",
                     "rightExpression": {
                       "argumentTypes": null,
-                      "id": 407,
+                      "id": 417,
                       "name": "token",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 253,
-                      "src": "2445:5:3",
+                      "src": "2524:5:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "2438:12:3",
+                    "src": "2517:12:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
                   "falseBody": null,
-                  "id": 412,
+                  "id": 422,
                   "nodeType": "IfStatement",
-                  "src": "2434:45:3",
+                  "src": "2513:45:3",
                   "trueBody": {
-                    "id": 411,
+                    "id": 421,
                     "nodeType": "Block",
-                    "src": "2452:27:3",
+                    "src": "2531:27:3",
                     "statements": [
                       {
                         "expression": {
                           "argumentTypes": null,
                           "hexValue": "66616c7365",
-                          "id": 409,
+                          "id": 419,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
                           "kind": "bool",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2467:5:3",
+                          "src": "2546:5:3",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -2131,10 +2266,10 @@
                           },
                           "value": "false"
                         },
-                        "functionReturnParameters": 405,
-                        "id": 410,
+                        "functionReturnParameters": 415,
+                        "id": 420,
                         "nodeType": "Return",
-                        "src": "2460:12:3"
+                        "src": "2539:12:3"
                       }
                     ]
                   }
@@ -2146,26 +2281,26 @@
                       "argumentTypes": null,
                       "baseExpression": {
                         "argumentTypes": null,
-                        "id": 413,
+                        "id": 423,
                         "name": "authorizations",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 259,
-                        "src": "2496:14:3",
+                        "src": "2571:14:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                           "typeString": "mapping(address => mapping(bytes4 => bool))"
                         }
                       },
-                      "id": 415,
+                      "id": 425,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 414,
+                        "id": 424,
                         "name": "src",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 397,
-                        "src": "2511:3:3",
+                        "referencedDeclaration": 407,
+                        "src": "2586:3:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -2176,21 +2311,21 @@
                       "isPure": false,
                       "lValueRequested": false,
                       "nodeType": "IndexAccess",
-                      "src": "2496:19:3",
+                      "src": "2571:19:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                         "typeString": "mapping(bytes4 => bool)"
                       }
                     },
-                    "id": 417,
+                    "id": 427,
                     "indexExpression": {
                       "argumentTypes": null,
-                      "id": 416,
+                      "id": 426,
                       "name": "sig",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 401,
-                      "src": "2516:3:3",
+                      "referencedDeclaration": 411,
+                      "src": "2591:3:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bytes4",
                         "typeString": "bytes4"
@@ -2201,21 +2336,21 @@
                     "isPure": false,
                     "lValueRequested": false,
                     "nodeType": "IndexAccess",
-                    "src": "2496:24:3",
+                    "src": "2571:24:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "functionReturnParameters": 405,
-                  "id": 418,
+                  "functionReturnParameters": 415,
+                  "id": 428,
                   "nodeType": "Return",
-                  "src": "2489:31:3"
+                  "src": "2564:31:3"
                 }
               ]
             },
             "documentation": null,
-            "id": 420,
+            "id": 430,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": true,
@@ -2223,16 +2358,16 @@
             "name": "canCall",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 402,
+              "id": 412,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 397,
+                  "id": 407,
                   "name": "src",
                   "nodeType": "VariableDeclaration",
-                  "scope": 420,
-                  "src": "2363:11:3",
+                  "scope": 430,
+                  "src": "2442:11:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2240,10 +2375,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 396,
+                    "id": 406,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2363:7:3",
+                    "src": "2442:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -2254,11 +2389,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 399,
+                  "id": 409,
                   "name": "dst",
                   "nodeType": "VariableDeclaration",
-                  "scope": 420,
-                  "src": "2376:11:3",
+                  "scope": 430,
+                  "src": "2455:11:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2266,10 +2401,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 398,
+                    "id": 408,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2376:7:3",
+                    "src": "2455:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -2280,11 +2415,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 401,
+                  "id": 411,
                   "name": "sig",
                   "nodeType": "VariableDeclaration",
-                  "scope": 420,
-                  "src": "2389:10:3",
+                  "scope": 430,
+                  "src": "2468:10:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2292,10 +2427,10 @@
                     "typeString": "bytes4"
                   },
                   "typeName": {
-                    "id": 400,
+                    "id": 410,
                     "name": "bytes4",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2389:6:3",
+                    "src": "2468:6:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes4",
                       "typeString": "bytes4"
@@ -2305,20 +2440,20 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2362:38:3"
+              "src": "2441:38:3"
             },
             "payable": false,
             "returnParameters": {
-              "id": 405,
+              "id": 415,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 404,
+                  "id": 414,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 420,
-                  "src": "2422:4:3",
+                  "scope": 430,
+                  "src": "2501:4:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2326,10 +2461,10 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 403,
+                    "id": 413,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2422:4:3",
+                    "src": "2501:4:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
@@ -2339,29 +2474,29 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2421:6:3"
+              "src": "2500:6:3"
             },
-            "scope": 421,
-            "src": "2346:179:3",
+            "scope": 431,
+            "src": "2425:175:3",
             "stateMutability": "view",
-            "superFunction": 1895,
+            "superFunction": 2086,
             "visibility": "public"
           }
         ],
-        "scope": 422,
-        "src": "762:1765:3"
+        "scope": 432,
+        "src": "762:1840:3"
       }
     ],
-    "src": "700:1827:3"
+    "src": "700:1903:3"
   },
   "legacyAST": {
     "absolutePath": "/Users/Elena/colonyToken/contracts/TokenAuthority.sol",
     "exportedSymbols": {
       "TokenAuthority": [
-        421
+        431
       ]
     },
-    "id": 422,
+    "id": 432,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -2380,8 +2515,8 @@
         "file": "../lib/dappsys/auth.sol",
         "id": 249,
         "nodeType": "ImportDirective",
-        "scope": 422,
-        "sourceUnit": 2015,
+        "scope": 432,
+        "sourceUnit": 2206,
         "src": "726:33:3",
         "symbolAliases": [],
         "unitAlias": ""
@@ -2395,10 +2530,10 @@
               "id": 250,
               "name": "DSAuthority",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 1896,
+              "referencedDeclaration": 2087,
               "src": "789:11:3",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_DSAuthority_$1896",
+                "typeIdentifier": "t_contract$_DSAuthority_$2087",
                 "typeString": "contract DSAuthority"
               }
             },
@@ -2408,15 +2543,15 @@
           }
         ],
         "contractDependencies": [
-          1896
+          2087
         ],
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 421,
+        "id": 431,
         "linearizedBaseContracts": [
-          421,
-          1896
+          431,
+          2087
         ],
         "name": "TokenAuthority",
         "nodeType": "ContractDefinition",
@@ -2426,7 +2561,7 @@
             "id": 253,
             "name": "token",
             "nodeType": "VariableDeclaration",
-            "scope": 421,
+            "scope": 431,
             "src": "805:20:3",
             "stateVariable": true,
             "storageLocation": "default",
@@ -2452,7 +2587,7 @@
             "id": 259,
             "name": "authorizations",
             "nodeType": "VariableDeclaration",
-            "scope": 421,
+            "scope": 431,
             "src": "829:58:3",
             "stateVariable": true,
             "storageLocation": "default",
@@ -2513,26 +2648,26 @@
           },
           {
             "body": {
-              "id": 394,
+              "id": 404,
               "nodeType": "Block",
-              "src": "1058:1284:3",
+              "src": "1080:1341:3",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 277,
+                    "id": 279,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 275,
+                      "id": 277,
                       "name": "token",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 253,
-                      "src": "1064:5:3",
+                      "src": "1086:5:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -2542,39 +2677,39 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 276,
+                      "id": 278,
                       "name": "_token",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 261,
-                      "src": "1072:6:3",
+                      "src": "1094:6:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "1064:14:3",
+                    "src": "1086:14:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     }
                   },
-                  "id": 278,
+                  "id": 280,
                   "nodeType": "ExpressionStatement",
-                  "src": "1064:14:3"
+                  "src": "1086:14:3"
                 },
                 {
                   "assignments": [
-                    280
+                    282
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 280,
+                      "id": 282,
                       "name": "transferSig",
                       "nodeType": "VariableDeclaration",
-                      "scope": 395,
-                      "src": "1084:18:3",
+                      "scope": 405,
+                      "src": "1106:18:3",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -2582,10 +2717,10 @@
                         "typeString": "bytes4"
                       },
                       "typeName": {
-                        "id": 279,
+                        "id": 281,
                         "name": "bytes4",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1084:6:3",
+                        "src": "1106:6:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -2595,7 +2730,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 286,
+                  "id": 288,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -2605,14 +2740,14 @@
                           {
                             "argumentTypes": null,
                             "hexValue": "7472616e7366657228616464726573732c75696e7432353629",
-                            "id": 283,
+                            "id": 285,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "string",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "1122:27:3",
+                            "src": "1144:27:3",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_stringliteral_a9059cbb2ab09eb219583f4a59a5d0623ade346d962bcd4e46b11da047c9049b",
@@ -2628,18 +2763,18 @@
                               "typeString": "literal_string \"transfer(address,uint256)\""
                             }
                           ],
-                          "id": 282,
+                          "id": 284,
                           "name": "keccak256",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2580,
-                          "src": "1112:9:3",
+                          "referencedDeclaration": 2771,
+                          "src": "1134:9:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_sha3_pure$__$returns$_t_bytes32_$",
                             "typeString": "function () pure returns (bytes32)"
                           }
                         },
-                        "id": 284,
+                        "id": 286,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -2647,7 +2782,7 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "1112:38:3",
+                        "src": "1134:38:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes32",
                           "typeString": "bytes32"
@@ -2661,20 +2796,20 @@
                           "typeString": "bytes32"
                         }
                       ],
-                      "id": 281,
+                      "id": 283,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "lValueRequested": false,
                       "nodeType": "ElementaryTypeNameExpression",
-                      "src": "1105:6:3",
+                      "src": "1127:6:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_type$_t_bytes4_$",
                         "typeString": "type(bytes4)"
                       },
                       "typeName": "bytes4"
                     },
-                    "id": 285,
+                    "id": 287,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
@@ -2682,27 +2817,27 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1105:46:3",
+                    "src": "1127:46:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes4",
                       "typeString": "bytes4"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1084:67:3"
+                  "src": "1106:67:3"
                 },
                 {
                   "assignments": [
-                    288
+                    290
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 288,
+                      "id": 290,
                       "name": "transferFromSig",
                       "nodeType": "VariableDeclaration",
-                      "scope": 395,
-                      "src": "1157:22:3",
+                      "scope": 405,
+                      "src": "1179:22:3",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -2710,10 +2845,10 @@
                         "typeString": "bytes4"
                       },
                       "typeName": {
-                        "id": 287,
+                        "id": 289,
                         "name": "bytes4",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1157:6:3",
+                        "src": "1179:6:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -2723,7 +2858,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 294,
+                  "id": 296,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -2733,14 +2868,14 @@
                           {
                             "argumentTypes": null,
                             "hexValue": "7472616e7366657246726f6d28616464726573732c616464726573732c75696e7432353629",
-                            "id": 291,
+                            "id": 293,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "string",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "1199:39:3",
+                            "src": "1221:39:3",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_stringliteral_23b872dd7302113369cda2901243429419bec145408fa8b352b3dd92b66c680b",
@@ -2756,18 +2891,18 @@
                               "typeString": "literal_string \"transferFrom(address,address,uint256)\""
                             }
                           ],
-                          "id": 290,
+                          "id": 292,
                           "name": "keccak256",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2580,
-                          "src": "1189:9:3",
+                          "referencedDeclaration": 2771,
+                          "src": "1211:9:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_sha3_pure$__$returns$_t_bytes32_$",
                             "typeString": "function () pure returns (bytes32)"
                           }
                         },
-                        "id": 292,
+                        "id": 294,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -2775,7 +2910,7 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "1189:50:3",
+                        "src": "1211:50:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes32",
                           "typeString": "bytes32"
@@ -2789,20 +2924,20 @@
                           "typeString": "bytes32"
                         }
                       ],
-                      "id": 289,
+                      "id": 291,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "lValueRequested": false,
                       "nodeType": "ElementaryTypeNameExpression",
-                      "src": "1182:6:3",
+                      "src": "1204:6:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_type$_t_bytes4_$",
                         "typeString": "type(bytes4)"
                       },
                       "typeName": "bytes4"
                     },
-                    "id": 293,
+                    "id": 295,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
@@ -2810,27 +2945,27 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1182:58:3",
+                    "src": "1204:58:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes4",
                       "typeString": "bytes4"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1157:83:3"
+                  "src": "1179:83:3"
                 },
                 {
                   "assignments": [
-                    296
+                    298
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 296,
+                      "id": 298,
                       "name": "mintSig",
                       "nodeType": "VariableDeclaration",
-                      "scope": 395,
-                      "src": "1246:14:3",
+                      "scope": 405,
+                      "src": "1268:14:3",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -2838,10 +2973,10 @@
                         "typeString": "bytes4"
                       },
                       "typeName": {
-                        "id": 295,
+                        "id": 297,
                         "name": "bytes4",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1246:6:3",
+                        "src": "1268:6:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -2851,7 +2986,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 302,
+                  "id": 304,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -2861,14 +2996,14 @@
                           {
                             "argumentTypes": null,
                             "hexValue": "6d696e742875696e7432353629",
-                            "id": 299,
+                            "id": 301,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "string",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "1280:15:3",
+                            "src": "1302:15:3",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_stringliteral_a0712d680358d64f694230b7cc0b277c73686bdf768385d55cd7c547d0ffd30e",
@@ -2884,18 +3019,18 @@
                               "typeString": "literal_string \"mint(uint256)\""
                             }
                           ],
-                          "id": 298,
+                          "id": 300,
                           "name": "keccak256",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2580,
-                          "src": "1270:9:3",
+                          "referencedDeclaration": 2771,
+                          "src": "1292:9:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_sha3_pure$__$returns$_t_bytes32_$",
                             "typeString": "function () pure returns (bytes32)"
                           }
                         },
-                        "id": 300,
+                        "id": 302,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -2903,7 +3038,7 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "1270:26:3",
+                        "src": "1292:26:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes32",
                           "typeString": "bytes32"
@@ -2917,20 +3052,20 @@
                           "typeString": "bytes32"
                         }
                       ],
-                      "id": 297,
+                      "id": 299,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "lValueRequested": false,
                       "nodeType": "ElementaryTypeNameExpression",
-                      "src": "1263:6:3",
+                      "src": "1285:6:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_type$_t_bytes4_$",
                         "typeString": "type(bytes4)"
                       },
                       "typeName": "bytes4"
                     },
-                    "id": 301,
+                    "id": 303,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
@@ -2938,19 +3073,19 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1263:34:3",
+                    "src": "1285:34:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes4",
                       "typeString": "bytes4"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1246:51:3"
+                  "src": "1268:51:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 309,
+                    "id": 311,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2961,26 +3096,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 303,
+                          "id": 305,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1304:14:3",
+                          "src": "1326:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 306,
+                        "id": 308,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 304,
+                          "id": 306,
                           "name": "_colonyNetwork",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 263,
-                          "src": "1319:14:3",
+                          "src": "1341:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -2991,21 +3126,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1304:30:3",
+                        "src": "1326:30:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 307,
+                      "id": 309,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 305,
+                        "id": 307,
                         "name": "transferSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 280,
-                        "src": "1335:11:3",
+                        "referencedDeclaration": 282,
+                        "src": "1357:11:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -3016,7 +3151,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1304:43:3",
+                      "src": "1326:43:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -3027,14 +3162,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 308,
+                      "id": 310,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1350:4:3",
+                      "src": "1372:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -3042,20 +3177,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1304:50:3",
+                    "src": "1326:50:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 310,
+                  "id": 312,
                   "nodeType": "ExpressionStatement",
-                  "src": "1304:50:3"
+                  "src": "1326:50:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 317,
+                    "id": 319,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3066,26 +3201,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 311,
+                          "id": 313,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1411:14:3",
+                          "src": "1433:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 314,
+                        "id": 316,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 312,
+                          "id": 314,
                           "name": "_colonyNetwork",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 263,
-                          "src": "1426:14:3",
+                          "src": "1448:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -3096,21 +3231,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1411:30:3",
+                        "src": "1433:30:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 315,
+                      "id": 317,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 313,
+                        "id": 315,
                         "name": "transferFromSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 288,
-                        "src": "1442:15:3",
+                        "referencedDeclaration": 290,
+                        "src": "1464:15:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -3121,7 +3256,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1411:47:3",
+                      "src": "1433:47:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -3132,14 +3267,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 316,
+                      "id": 318,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1461:4:3",
+                      "src": "1483:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -3147,20 +3282,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1411:54:3",
+                    "src": "1433:54:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 318,
+                  "id": 320,
                   "nodeType": "ExpressionStatement",
-                  "src": "1411:54:3"
+                  "src": "1433:54:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 325,
+                    "id": 327,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3171,26 +3306,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 319,
+                          "id": 321,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1472:14:3",
+                          "src": "1494:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 322,
+                        "id": 324,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 320,
+                          "id": 322,
                           "name": "_metaColony",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 265,
-                          "src": "1487:11:3",
+                          "src": "1509:11:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -3201,21 +3336,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1472:27:3",
+                        "src": "1494:27:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 323,
+                      "id": 325,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 321,
+                        "id": 323,
                         "name": "transferSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 280,
-                        "src": "1500:11:3",
+                        "referencedDeclaration": 282,
+                        "src": "1522:11:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -3226,7 +3361,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1472:40:3",
+                      "src": "1494:40:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -3237,14 +3372,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 324,
+                      "id": 326,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1515:4:3",
+                      "src": "1537:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -3252,20 +3387,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1472:47:3",
+                    "src": "1494:47:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 326,
+                  "id": 328,
                   "nodeType": "ExpressionStatement",
-                  "src": "1472:47:3"
+                  "src": "1494:47:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 333,
+                    "id": 335,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3276,26 +3411,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 327,
+                          "id": 329,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1694:14:3",
+                          "src": "1716:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 330,
+                        "id": 332,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 328,
+                          "id": 330,
                           "name": "_metaColony",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 265,
-                          "src": "1709:11:3",
+                          "src": "1731:11:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -3306,21 +3441,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1694:27:3",
+                        "src": "1716:27:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 331,
+                      "id": 333,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 329,
+                        "id": 331,
                         "name": "mintSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 296,
-                        "src": "1722:7:3",
+                        "referencedDeclaration": 298,
+                        "src": "1744:7:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -3331,7 +3466,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1694:36:3",
+                      "src": "1716:36:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -3342,14 +3477,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 332,
+                      "id": 334,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1733:4:3",
+                      "src": "1755:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -3357,20 +3492,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1694:43:3",
+                    "src": "1716:43:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 334,
+                  "id": 336,
                   "nodeType": "ExpressionStatement",
-                  "src": "1694:43:3"
+                  "src": "1716:43:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 341,
+                    "id": 343,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3381,26 +3516,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 335,
+                          "id": 337,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1801:14:3",
+                          "src": "1823:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 338,
+                        "id": 340,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 336,
+                          "id": 338,
                           "name": "_tokenLocking",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 267,
-                          "src": "1816:13:3",
+                          "src": "1838:13:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -3411,21 +3546,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1801:29:3",
+                        "src": "1823:29:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 339,
+                      "id": 341,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 337,
+                        "id": 339,
                         "name": "transferSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 280,
-                        "src": "1831:11:3",
+                        "referencedDeclaration": 282,
+                        "src": "1853:11:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -3436,7 +3571,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1801:42:3",
+                      "src": "1823:42:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -3447,14 +3582,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 340,
+                      "id": 342,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1846:4:3",
+                      "src": "1868:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -3462,20 +3597,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1801:49:3",
+                    "src": "1823:49:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 342,
+                  "id": 344,
                   "nodeType": "ExpressionStatement",
-                  "src": "1801:49:3"
+                  "src": "1823:49:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 349,
+                    "id": 351,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3486,26 +3621,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 343,
+                          "id": 345,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1895:14:3",
+                          "src": "1917:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 346,
+                        "id": 348,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 344,
+                          "id": 346,
                           "name": "_tokenLocking",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 267,
-                          "src": "1910:13:3",
+                          "src": "1932:13:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -3516,21 +3651,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1895:29:3",
+                        "src": "1917:29:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 347,
+                      "id": 349,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 345,
+                        "id": 347,
                         "name": "transferFromSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 288,
-                        "src": "1925:15:3",
+                        "referencedDeclaration": 290,
+                        "src": "1947:15:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -3541,7 +3676,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1895:46:3",
+                      "src": "1917:46:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -3552,14 +3687,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 348,
+                      "id": 350,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "1944:4:3",
+                      "src": "1966:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -3567,20 +3702,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1895:53:3",
+                    "src": "1917:53:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 350,
+                  "id": 352,
                   "nodeType": "ExpressionStatement",
-                  "src": "1895:53:3"
+                  "src": "1917:53:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 357,
+                    "id": 359,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3591,26 +3726,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 351,
+                          "id": 353,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "1989:14:3",
+                          "src": "2011:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 354,
+                        "id": 356,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 352,
+                          "id": 354,
                           "name": "_vesting",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 269,
-                          "src": "2004:8:3",
+                          "src": "2026:8:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -3621,21 +3756,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1989:24:3",
+                        "src": "2011:24:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 355,
+                      "id": 357,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 353,
+                        "id": 355,
                         "name": "transferSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 280,
-                        "src": "2014:11:3",
+                        "referencedDeclaration": 282,
+                        "src": "2036:11:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -3646,7 +3781,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1989:37:3",
+                      "src": "2011:37:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -3657,14 +3792,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 356,
+                      "id": 358,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "2029:4:3",
+                      "src": "2051:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -3672,20 +3807,20 @@
                       },
                       "value": "true"
                     },
-                    "src": "1989:44:3",
+                    "src": "2011:44:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 358,
+                  "id": 360,
                   "nodeType": "ExpressionStatement",
-                  "src": "1989:44:3"
+                  "src": "2011:44:3"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 365,
+                    "id": 367,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3696,26 +3831,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 359,
+                          "id": 361,
                           "name": "authorizations",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 259,
-                          "src": "2039:14:3",
+                          "src": "2061:14:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                             "typeString": "mapping(address => mapping(bytes4 => bool))"
                           }
                         },
-                        "id": 362,
+                        "id": 364,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 360,
+                          "id": 362,
                           "name": "_vesting",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 269,
-                          "src": "2054:8:3",
+                          "src": "2076:8:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -3726,21 +3861,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "2039:24:3",
+                        "src": "2061:24:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                           "typeString": "mapping(bytes4 => bool)"
                         }
                       },
-                      "id": 363,
+                      "id": 365,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 361,
+                        "id": 363,
                         "name": "transferFromSig",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 288,
-                        "src": "2064:15:3",
+                        "referencedDeclaration": 290,
+                        "src": "2086:15:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes4",
                           "typeString": "bytes4"
@@ -3751,7 +3886,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "2039:41:3",
+                      "src": "2061:41:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -3762,14 +3897,14 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "74727565",
-                      "id": 364,
+                      "id": 366,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "bool",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "2083:4:3",
+                      "src": "2105:4:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -3777,34 +3912,34 @@
                       },
                       "value": "true"
                     },
-                    "src": "2039:48:3",
+                    "src": "2061:48:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 366,
+                  "id": 368,
                   "nodeType": "ExpressionStatement",
-                  "src": "2039:48:3"
+                  "src": "2061:48:3"
                 },
                 {
                   "body": {
-                    "id": 392,
+                    "id": 394,
                     "nodeType": "Block",
-                    "src": "2249:89:3",
+                    "src": "2271:89:3",
                     "statements": [
                       {
                         "assignments": [
-                          379
+                          381
                         ],
                         "declarations": [
                           {
                             "constant": false,
-                            "id": 379,
+                            "id": 381,
                             "name": "miner",
                             "nodeType": "VariableDeclaration",
-                            "scope": 395,
-                            "src": "2257:13:3",
+                            "scope": 405,
+                            "src": "2279:13:3",
                             "stateVariable": false,
                             "storageLocation": "default",
                             "typeDescriptions": {
@@ -3812,10 +3947,10 @@
                               "typeString": "address"
                             },
                             "typeName": {
-                              "id": 378,
+                              "id": 380,
                               "name": "address",
                               "nodeType": "ElementaryTypeName",
-                              "src": "2257:7:3",
+                              "src": "2279:7:3",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
@@ -3825,31 +3960,31 @@
                             "visibility": "internal"
                           }
                         ],
-                        "id": 383,
+                        "id": 385,
                         "initialValue": {
                           "argumentTypes": null,
                           "baseExpression": {
                             "argumentTypes": null,
-                            "id": 380,
+                            "id": 382,
                             "name": "miners",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
                             "referencedDeclaration": 272,
-                            "src": "2273:6:3",
+                            "src": "2295:6:3",
                             "typeDescriptions": {
                               "typeIdentifier": "t_array$_t_address_$dyn_memory_ptr",
                               "typeString": "address[] memory"
                             }
                           },
-                          "id": 382,
+                          "id": 384,
                           "indexExpression": {
                             "argumentTypes": null,
-                            "id": 381,
+                            "id": 383,
                             "name": "i",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 368,
-                            "src": "2280:1:3",
+                            "referencedDeclaration": 370,
+                            "src": "2302:1:3",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
@@ -3860,19 +3995,19 @@
                           "isPure": false,
                           "lValueRequested": false,
                           "nodeType": "IndexAccess",
-                          "src": "2273:9:3",
+                          "src": "2295:9:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
                         "nodeType": "VariableDeclarationStatement",
-                        "src": "2257:25:3"
+                        "src": "2279:25:3"
                       },
                       {
                         "expression": {
                           "argumentTypes": null,
-                          "id": 390,
+                          "id": 392,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -3883,26 +4018,26 @@
                               "argumentTypes": null,
                               "baseExpression": {
                                 "argumentTypes": null,
-                                "id": 384,
+                                "id": 386,
                                 "name": "authorizations",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
                                 "referencedDeclaration": 259,
-                                "src": "2290:14:3",
+                                "src": "2312:14:3",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                                   "typeString": "mapping(address => mapping(bytes4 => bool))"
                                 }
                               },
-                              "id": 387,
+                              "id": 389,
                               "indexExpression": {
                                 "argumentTypes": null,
-                                "id": 385,
+                                "id": 387,
                                 "name": "miner",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 379,
-                                "src": "2305:5:3",
+                                "referencedDeclaration": 381,
+                                "src": "2327:5:3",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
                                   "typeString": "address"
@@ -3913,21 +4048,21 @@
                               "isPure": false,
                               "lValueRequested": false,
                               "nodeType": "IndexAccess",
-                              "src": "2290:21:3",
+                              "src": "2312:21:3",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                                 "typeString": "mapping(bytes4 => bool)"
                               }
                             },
-                            "id": 388,
+                            "id": 390,
                             "indexExpression": {
                               "argumentTypes": null,
-                              "id": 386,
+                              "id": 388,
                               "name": "transferSig",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 280,
-                              "src": "2312:11:3",
+                              "referencedDeclaration": 282,
+                              "src": "2334:11:3",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_bytes4",
                                 "typeString": "bytes4"
@@ -3938,7 +4073,7 @@
                             "isPure": false,
                             "lValueRequested": true,
                             "nodeType": "IndexAccess",
-                            "src": "2290:34:3",
+                            "src": "2312:34:3",
                             "typeDescriptions": {
                               "typeIdentifier": "t_bool",
                               "typeString": "bool"
@@ -3949,14 +4084,14 @@
                           "rightHandSide": {
                             "argumentTypes": null,
                             "hexValue": "74727565",
-                            "id": 389,
+                            "id": 391,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "kind": "bool",
                             "lValueRequested": false,
                             "nodeType": "Literal",
-                            "src": "2327:4:3",
+                            "src": "2349:4:3",
                             "subdenomination": null,
                             "typeDescriptions": {
                               "typeIdentifier": "t_bool",
@@ -3964,15 +4099,15 @@
                             },
                             "value": "true"
                           },
-                          "src": "2290:41:3",
+                          "src": "2312:41:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
                             "typeString": "bool"
                           }
                         },
-                        "id": 391,
+                        "id": 393,
                         "nodeType": "ExpressionStatement",
-                        "src": "2290:41:3"
+                        "src": "2312:41:3"
                       }
                     ]
                   },
@@ -3982,19 +4117,19 @@
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
                     },
-                    "id": 374,
+                    "id": 376,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftExpression": {
                       "argumentTypes": null,
-                      "id": 371,
+                      "id": 373,
                       "name": "i",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 368,
-                      "src": "2225:1:3",
+                      "referencedDeclaration": 370,
+                      "src": "2247:1:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
@@ -4006,18 +4141,18 @@
                       "argumentTypes": null,
                       "expression": {
                         "argumentTypes": null,
-                        "id": 372,
+                        "id": 374,
                         "name": "miners",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 272,
-                        "src": "2229:6:3",
+                        "src": "2251:6:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_array$_t_address_$dyn_memory_ptr",
                           "typeString": "address[] memory"
                         }
                       },
-                      "id": 373,
+                      "id": 375,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -4025,31 +4160,31 @@
                       "memberName": "length",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "2229:13:3",
+                      "src": "2251:13:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       }
                     },
-                    "src": "2225:17:3",
+                    "src": "2247:17:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "id": 393,
+                  "id": 395,
                   "initializationExpression": {
                     "assignments": [
-                      368
+                      370
                     ],
                     "declarations": [
                       {
                         "constant": false,
-                        "id": 368,
+                        "id": 370,
                         "name": "i",
                         "nodeType": "VariableDeclaration",
-                        "scope": 395,
-                        "src": "2213:6:3",
+                        "scope": 405,
+                        "src": "2235:6:3",
                         "stateVariable": false,
                         "storageLocation": "default",
                         "typeDescriptions": {
@@ -4057,10 +4192,10 @@
                           "typeString": "uint256"
                         },
                         "typeName": {
-                          "id": 367,
+                          "id": 369,
                           "name": "uint",
                           "nodeType": "ElementaryTypeName",
-                          "src": "2213:4:3",
+                          "src": "2235:4:3",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
@@ -4070,18 +4205,18 @@
                         "visibility": "internal"
                       }
                     ],
-                    "id": 370,
+                    "id": 372,
                     "initialValue": {
                       "argumentTypes": null,
                       "hexValue": "30",
-                      "id": 369,
+                      "id": 371,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
                       "kind": "number",
                       "lValueRequested": false,
                       "nodeType": "Literal",
-                      "src": "2222:1:3",
+                      "src": "2244:1:3",
                       "subdenomination": null,
                       "typeDescriptions": {
                         "typeIdentifier": "t_rational_0_by_1",
@@ -4090,12 +4225,12 @@
                       "value": "0"
                     },
                     "nodeType": "VariableDeclarationStatement",
-                    "src": "2213:10:3"
+                    "src": "2235:10:3"
                   },
                   "loopExpression": {
                     "expression": {
                       "argumentTypes": null,
-                      "id": 376,
+                      "id": 378,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -4103,15 +4238,15 @@
                       "nodeType": "UnaryOperation",
                       "operator": "++",
                       "prefix": false,
-                      "src": "2244:3:3",
+                      "src": "2266:3:3",
                       "subExpression": {
                         "argumentTypes": null,
-                        "id": 375,
+                        "id": 377,
                         "name": "i",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 368,
-                        "src": "2244:1:3",
+                        "referencedDeclaration": 370,
+                        "src": "2266:1:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -4122,17 +4257,122 @@
                         "typeString": "uint256"
                       }
                     },
-                    "id": 377,
+                    "id": 379,
                     "nodeType": "ExpressionStatement",
-                    "src": "2244:3:3"
+                    "src": "2266:3:3"
                   },
                   "nodeType": "ForStatement",
-                  "src": "2208:130:3"
+                  "src": "2230:130:3"
+                },
+                {
+                  "expression": {
+                    "argumentTypes": null,
+                    "id": 402,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "argumentTypes": null,
+                      "baseExpression": {
+                        "argumentTypes": null,
+                        "baseExpression": {
+                          "argumentTypes": null,
+                          "id": 396,
+                          "name": "authorizations",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 259,
+                          "src": "2366:14:3",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
+                            "typeString": "mapping(address => mapping(bytes4 => bool))"
+                          }
+                        },
+                        "id": 399,
+                        "indexExpression": {
+                          "argumentTypes": null,
+                          "id": 397,
+                          "name": "_regulator",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 274,
+                          "src": "2381:10:3",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "isConstant": false,
+                        "isLValue": true,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "nodeType": "IndexAccess",
+                        "src": "2366:26:3",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
+                          "typeString": "mapping(bytes4 => bool)"
+                        }
+                      },
+                      "id": 400,
+                      "indexExpression": {
+                        "argumentTypes": null,
+                        "id": 398,
+                        "name": "transferFromSig",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 290,
+                        "src": "2393:15:3",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes4",
+                          "typeString": "bytes4"
+                        }
+                      },
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "nodeType": "IndexAccess",
+                      "src": "2366:43:3",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "argumentTypes": null,
+                      "hexValue": "74727565",
+                      "id": 401,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "bool",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "2412:4:3",
+                      "subdenomination": null,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      },
+                      "value": "true"
+                    },
+                    "src": "2366:50:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "id": 403,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2366:50:3"
                 }
               ]
             },
             "documentation": null,
-            "id": 395,
+            "id": 405,
             "implemented": true,
             "isConstructor": true,
             "isDeclaredConst": false,
@@ -4140,7 +4380,7 @@
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 273,
+              "id": 275,
               "nodeType": "ParameterList",
               "parameters": [
                 {
@@ -4148,8 +4388,8 @@
                   "id": 261,
                   "name": "_token",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "911:14:3",
+                  "scope": 405,
+                  "src": "909:14:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4160,7 +4400,7 @@
                     "id": 260,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "911:7:3",
+                    "src": "909:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -4174,8 +4414,8 @@
                   "id": 263,
                   "name": "_colonyNetwork",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "931:22:3",
+                  "scope": 405,
+                  "src": "929:22:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4186,7 +4426,7 @@
                     "id": 262,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "931:7:3",
+                    "src": "929:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -4200,8 +4440,8 @@
                   "id": 265,
                   "name": "_metaColony",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "959:19:3",
+                  "scope": 405,
+                  "src": "957:19:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4212,7 +4452,7 @@
                     "id": 264,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "959:7:3",
+                    "src": "957:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -4226,8 +4466,8 @@
                   "id": 267,
                   "name": "_tokenLocking",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "984:21:3",
+                  "scope": 405,
+                  "src": "982:21:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4238,7 +4478,7 @@
                     "id": 266,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "984:7:3",
+                    "src": "982:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -4252,8 +4492,8 @@
                   "id": 269,
                   "name": "_vesting",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "1011:16:3",
+                  "scope": 405,
+                  "src": "1009:16:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4264,7 +4504,7 @@
                     "id": 268,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1011:7:3",
+                    "src": "1009:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -4278,8 +4518,8 @@
                   "id": 272,
                   "name": "miners",
                   "nodeType": "VariableDeclaration",
-                  "scope": 395,
-                  "src": "1033:16:3",
+                  "scope": 405,
+                  "src": "1031:16:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4291,7 +4531,7 @@
                       "id": 270,
                       "name": "address",
                       "nodeType": "ElementaryTypeName",
-                      "src": "1033:7:3",
+                      "src": "1031:7:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -4300,7 +4540,7 @@
                     "id": 271,
                     "length": null,
                     "nodeType": "ArrayTypeName",
-                    "src": "1033:9:3",
+                    "src": "1031:9:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_array$_t_address_$dyn_storage_ptr",
                       "typeString": "address[]"
@@ -4308,28 +4548,54 @@
                   },
                   "value": null,
                   "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 274,
+                  "name": "_regulator",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 405,
+                  "src": "1053:18:3",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 273,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1053:7:3",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
                 }
               ],
-              "src": "905:145:3"
+              "src": "903:169:3"
             },
             "payable": false,
             "returnParameters": {
-              "id": 274,
+              "id": 276,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1058:0:3"
+              "src": "1080:0:3"
             },
-            "scope": 421,
-            "src": "894:1448:3",
+            "scope": 431,
+            "src": "892:1529:3",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           },
           {
             "body": {
-              "id": 419,
+              "id": 429,
               "nodeType": "Block",
-              "src": "2428:97:3",
+              "src": "2507:93:3",
               "statements": [
                 {
                   "condition": {
@@ -4338,19 +4604,19 @@
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     },
-                    "id": 408,
+                    "id": 418,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftExpression": {
                       "argumentTypes": null,
-                      "id": 406,
+                      "id": 416,
                       "name": "dst",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 399,
-                      "src": "2438:3:3",
+                      "referencedDeclaration": 409,
+                      "src": "2517:3:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -4360,44 +4626,44 @@
                     "operator": "!=",
                     "rightExpression": {
                       "argumentTypes": null,
-                      "id": 407,
+                      "id": 417,
                       "name": "token",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 253,
-                      "src": "2445:5:3",
+                      "src": "2524:5:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "2438:12:3",
+                    "src": "2517:12:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
                   "falseBody": null,
-                  "id": 412,
+                  "id": 422,
                   "nodeType": "IfStatement",
-                  "src": "2434:45:3",
+                  "src": "2513:45:3",
                   "trueBody": {
-                    "id": 411,
+                    "id": 421,
                     "nodeType": "Block",
-                    "src": "2452:27:3",
+                    "src": "2531:27:3",
                     "statements": [
                       {
                         "expression": {
                           "argumentTypes": null,
                           "hexValue": "66616c7365",
-                          "id": 409,
+                          "id": 419,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
                           "kind": "bool",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2467:5:3",
+                          "src": "2546:5:3",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -4405,10 +4671,10 @@
                           },
                           "value": "false"
                         },
-                        "functionReturnParameters": 405,
-                        "id": 410,
+                        "functionReturnParameters": 415,
+                        "id": 420,
                         "nodeType": "Return",
-                        "src": "2460:12:3"
+                        "src": "2539:12:3"
                       }
                     ]
                   }
@@ -4420,26 +4686,26 @@
                       "argumentTypes": null,
                       "baseExpression": {
                         "argumentTypes": null,
-                        "id": 413,
+                        "id": 423,
                         "name": "authorizations",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
                         "referencedDeclaration": 259,
-                        "src": "2496:14:3",
+                        "src": "2571:14:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_bytes4_$_t_bool_$_$",
                           "typeString": "mapping(address => mapping(bytes4 => bool))"
                         }
                       },
-                      "id": 415,
+                      "id": 425,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 414,
+                        "id": 424,
                         "name": "src",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 397,
-                        "src": "2511:3:3",
+                        "referencedDeclaration": 407,
+                        "src": "2586:3:3",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -4450,21 +4716,21 @@
                       "isPure": false,
                       "lValueRequested": false,
                       "nodeType": "IndexAccess",
-                      "src": "2496:19:3",
+                      "src": "2571:19:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_mapping$_t_bytes4_$_t_bool_$",
                         "typeString": "mapping(bytes4 => bool)"
                       }
                     },
-                    "id": 417,
+                    "id": 427,
                     "indexExpression": {
                       "argumentTypes": null,
-                      "id": 416,
+                      "id": 426,
                       "name": "sig",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 401,
-                      "src": "2516:3:3",
+                      "referencedDeclaration": 411,
+                      "src": "2591:3:3",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bytes4",
                         "typeString": "bytes4"
@@ -4475,21 +4741,21 @@
                     "isPure": false,
                     "lValueRequested": false,
                     "nodeType": "IndexAccess",
-                    "src": "2496:24:3",
+                    "src": "2571:24:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     }
                   },
-                  "functionReturnParameters": 405,
-                  "id": 418,
+                  "functionReturnParameters": 415,
+                  "id": 428,
                   "nodeType": "Return",
-                  "src": "2489:31:3"
+                  "src": "2564:31:3"
                 }
               ]
             },
             "documentation": null,
-            "id": 420,
+            "id": 430,
             "implemented": true,
             "isConstructor": false,
             "isDeclaredConst": true,
@@ -4497,16 +4763,16 @@
             "name": "canCall",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 402,
+              "id": 412,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 397,
+                  "id": 407,
                   "name": "src",
                   "nodeType": "VariableDeclaration",
-                  "scope": 420,
-                  "src": "2363:11:3",
+                  "scope": 430,
+                  "src": "2442:11:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4514,10 +4780,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 396,
+                    "id": 406,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2363:7:3",
+                    "src": "2442:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -4528,11 +4794,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 399,
+                  "id": 409,
                   "name": "dst",
                   "nodeType": "VariableDeclaration",
-                  "scope": 420,
-                  "src": "2376:11:3",
+                  "scope": 430,
+                  "src": "2455:11:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4540,10 +4806,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 398,
+                    "id": 408,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2376:7:3",
+                    "src": "2455:7:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
@@ -4554,11 +4820,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 401,
+                  "id": 411,
                   "name": "sig",
                   "nodeType": "VariableDeclaration",
-                  "scope": 420,
-                  "src": "2389:10:3",
+                  "scope": 430,
+                  "src": "2468:10:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4566,10 +4832,10 @@
                     "typeString": "bytes4"
                   },
                   "typeName": {
-                    "id": 400,
+                    "id": 410,
                     "name": "bytes4",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2389:6:3",
+                    "src": "2468:6:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes4",
                       "typeString": "bytes4"
@@ -4579,20 +4845,20 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2362:38:3"
+              "src": "2441:38:3"
             },
             "payable": false,
             "returnParameters": {
-              "id": 405,
+              "id": 415,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 404,
+                  "id": 414,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 420,
-                  "src": "2422:4:3",
+                  "scope": 430,
+                  "src": "2501:4:3",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4600,10 +4866,10 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 403,
+                    "id": 413,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2422:4:3",
+                    "src": "2501:4:3",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
@@ -4613,20 +4879,20 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2421:6:3"
+              "src": "2500:6:3"
             },
-            "scope": 421,
-            "src": "2346:179:3",
+            "scope": 431,
+            "src": "2425:175:3",
             "stateMutability": "view",
-            "superFunction": 1895,
+            "superFunction": 2086,
             "visibility": "public"
           }
         ],
-        "scope": 422,
-        "src": "762:1765:3"
+        "scope": 432,
+        "src": "762:1840:3"
       }
     ],
-    "src": "700:1827:3"
+    "src": "700:1903:3"
   },
   "compiler": {
     "name": "solc",
@@ -4634,5 +4900,5 @@
   },
   "networks": {},
   "schemaVersion": "3.0.0-beta.1",
-  "updatedAt": "2018-12-18T09:42:41.907Z"
+  "updatedAt": "2019-03-15T11:07:46.502Z"
 }

--- a/contracts/TokenAuthority.sol
+++ b/contracts/TokenAuthority.sol
@@ -23,14 +23,15 @@ import "../lib/dappsys/auth.sol";
 contract TokenAuthority is DSAuthority {
   address public token;
   mapping(address => mapping(bytes4 => bool)) authorizations;
-  
+
   constructor(
     address _token,
     address _colonyNetwork,
     address _metaColony,
     address _tokenLocking,
     address _vesting,
-    address[] miners) public {
+    address[] miners,
+    address _regulator) public {
     token = _token;
     bytes4 transferSig = bytes4(keccak256("transfer(address,uint256)"));
     bytes4 transferFromSig = bytes4(keccak256("transferFrom(address,address,uint256)"));
@@ -54,13 +55,15 @@ contract TokenAuthority is DSAuthority {
       address miner = miners[i];
       authorizations[miner][transferSig] = true;
     }
+
+    authorizations[_regulator][transferFromSig] = true;
   }
 
   function canCall(address src, address dst, bytes4 sig) public view returns (bool) {
     if (dst != token) {
       return false;
     }
-    
+
     return authorizations[src][sig];
   }
 }

--- a/contracts/TokenTransferBinaryRegulator.sol
+++ b/contracts/TokenTransferBinaryRegulator.sol
@@ -1,0 +1,57 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity >=0.4.23;
+
+import "./ERC20Extended.sol";
+
+
+contract TokenTransferBinaryRegulator {
+  struct Transfer {
+    address from;
+    address to;
+    address token;
+    uint256 amount;
+    bool valid;
+  }
+
+  mapping (uint256 => Transfer) public transfers;
+  uint public transferCount = 0;
+  address public owner;
+
+  constructor(address _owner) {
+    owner = _owner;
+  }
+
+  function invalidateRequest(uint256 _id) public {
+    require(transfers[_id].from == msg.sender || msg.sender == owner, "colony-token-regulator-not-from-address");
+    transfers[_id].valid = false;
+  }
+
+  function requestTransfer(address _from, address _to, address _token, uint256 _amount) public {
+    require(_from == msg.sender, "colony-token-regulator-not-from-address");
+    transfers[transferCount] = Transfer(_from, _to, _token, _amount, true);
+    transferCount += 1;
+  }
+
+  function executeTransfer(uint256 _id) public {
+    require(transfers[_id].valid == true, "colony-token-regulator-transfer-invalid-or-already-executed");
+    require(msg.sender == owner, "colony-token-regulator-only-owner-can-execute");
+    transfers[_id].valid = false;
+    ERC20Extended(transfers[_id].token).transferFrom(transfers[_id].from, transfers[_id].to, transfers[_id].amount);
+  }
+}

--- a/gasCosts/gasCosts.js
+++ b/gasCosts/gasCosts.js
@@ -13,6 +13,7 @@ contract("Vesting", accounts => {
   const SECONDS_PER_MONTH = 2628000;
   const COLONY_ACCOUNT = accounts[0];
   const ACCOUNT_1 = accounts[1];
+  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
   const ACCOUNT_1_GRANT_AMOUNT = new BN(web3Utils.toWei("998", "finney"));
 
@@ -21,20 +22,28 @@ contract("Vesting", accounts => {
 
   beforeEach(async () => {
     token = await Token.new("Colony token", "CLNY", 18);
-    await token.mint(ACCOUNT_1_GRANT_AMOUNT.toString());
+    await token.mint(ACCOUNT_1_GRANT_AMOUNT);
 
     vesting = await Vesting.new(token.address, COLONY_ACCOUNT);
     // Approve the total balance to be tranferred by the vesting contract as part of the `addTokenGrant` call
-    await token.approve(vesting.address, ACCOUNT_1_GRANT_AMOUNT.toString());
+    await token.approve(vesting.address, ACCOUNT_1_GRANT_AMOUNT);
 
-    const tokenAuthority = await TokenAuthority.new(token.address, vesting.address);
+    const tokenAuthority = await TokenAuthority.new(
+      token.address,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      vesting.address,
+      [ZERO_ADDRESS],
+      ZERO_ADDRESS
+    );
     const dsAuthToken = await DSAuth.at(token.address);
     await dsAuthToken.setAuthority(tokenAuthority.address);
   });
 
   describe("Gas costs", () => {
     it("working with grants", async () => {
-      await vesting.addTokenGrant(ACCOUNT_1, 0, ACCOUNT_1_GRANT_AMOUNT.toString(), 24, 6);
+      await vesting.addTokenGrant(ACCOUNT_1, 0, ACCOUNT_1_GRANT_AMOUNT, 24, 6);
       await forwardTime(SECONDS_PER_MONTH * 7);
       await vesting.claimVestedTokens({ from: ACCOUNT_1 });
       await vesting.removeTokenGrant(ACCOUNT_1);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -11,6 +11,6 @@ module.exports = (deployer, network, accounts) => {
     .deploy(MultiSigWallet, [COLONY_ACCOUNT], 1)
     .then(() => deployer.deploy(Token, "Colony Token", "CLNY", 18))
     .then(() => deployer.deploy(Vesting, Token.address, MultiSigWallet.address))
-    .then(() => deployer.deploy(TokenTransferBinaryRegulator, MultiSigWallet.address))
+    .then(() => deployer.deploy(TokenTransferBinaryRegulator, MultiSigWallet.address, Token.address))
     .then(() => deployer.deploy(TokenAuthority, Token.address, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, Vesting.address, [ZERO_ADDRESS], TokenTransferBinaryRegulator.address));
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -2,13 +2,15 @@ const MultiSigWallet = artifacts.require("./gnosis/MultiSigWallet");
 const TokenAuthority = artifacts.require("./TokenAuthority");
 const Token = artifacts.require("./Token");
 const Vesting = artifacts.require("./Vesting");
+const TokenTransferBinaryRegulator = artifacts.require("./TokenTransferBinaryRegulator");
 
 module.exports = (deployer, network, accounts) => {
   const COLONY_ACCOUNT = accounts[0];
-
+  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
   deployer
     .deploy(MultiSigWallet, [COLONY_ACCOUNT], 1)
     .then(() => deployer.deploy(Token, "Colony Token", "CLNY", 18))
     .then(() => deployer.deploy(Vesting, Token.address, MultiSigWallet.address))
-    .then(() => deployer.deploy(TokenAuthority, Token.address, Vesting.address));
+    .then(() => deployer.deploy(TokenTransferBinaryRegulator, MultiSigWallet.address))
+    .then(() => deployer.deploy(TokenAuthority, Token.address, ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, Vesting.address, [ZERO_ADDRESS], TokenTransferBinaryRegulator.address));
 };

--- a/test/token-transfer-binary-regulator.js
+++ b/test/token-transfer-binary-regulator.js
@@ -1,0 +1,128 @@
+/* globals artifacts */
+
+import { assert } from "chai";
+
+import { checkErrorRevert, expectEvent } from "../helpers/test-helper";
+
+const TokenTransferBinaryRegulator = artifacts.require("TokenTransferBinaryRegulator");
+const Token = artifacts.require("Token");
+const MultiSigWallet = artifacts.require("MultiSigWallet");
+
+contract("Binary Regulator", accounts => {
+  const ADDRESS_1 = accounts[1];
+  const ADDRESS_2 = accounts[2];
+
+  let regulator;
+  let token;
+  let colonyMultiSig;
+
+  before(async () => {
+    regulator = await TokenTransferBinaryRegulator.deployed();
+    // token = await Token.deployed();
+    // colonyMultiSig = await MultiSigWallet.deployed();
+    // vesting = await Vesting.deployed();
+    // tokenAuthority = await TokenAuthority.deployed();
+    // token = await Token.new("Colony token", "CLNY", 18);
+    token = await Token.deployed();
+    // const dsAuthToken = await DSAuth.at(token.address);
+    // await dsAuthToken.setAuthority(tokenAuthority.address);
+    // await token.unlock();
+    colonyMultiSig = await MultiSigWallet.deployed();
+  });
+
+  describe("when working with a locked token", () => {
+    it("should be able to submit transfers", async () => {
+      let txData = await token.contract.methods.mint(500).encodeABI();
+      await colonyMultiSig.submitTransaction(token.address, 0, txData);
+      txData = await token.contract.methods.transfer(ADDRESS_1, 500).encodeABI();
+      await colonyMultiSig.submitTransaction(token.address, 0, txData);
+
+      const a1BalanceBefore = await token.balanceOf(ADDRESS_1);
+      const a2BalanceBefore = await token.balanceOf(ADDRESS_2);
+
+      // Confirm we cannot send directly
+      await checkErrorRevert(token.transfer(ADDRESS_2, 500, { from: ADDRESS_1 }));
+
+      // Make request to regulator
+      await token.approve(regulator.address, 500, { from: ADDRESS_1 });
+      await regulator.requestTransfer(ADDRESS_1, ADDRESS_2, token.address, 500, { from: ADDRESS_1 });
+
+      const transferCount = await regulator.transferCount();
+
+      // Approve request through multisig
+      txData = await regulator.contract.methods.executeTransfer(transferCount - 1).encodeABI();
+      await colonyMultiSig.submitTransaction(regulator.address, 0, txData);
+
+      // Check it worked
+      const a1BalanceAfter = await token.balanceOf(ADDRESS_1);
+      assert.equal(a1BalanceBefore.sub(a1BalanceAfter).toString(), "500");
+
+      const a2BalanceAfter = await token.balanceOf(ADDRESS_2);
+      assert.equal(a2BalanceAfter.sub(a2BalanceBefore).toString(), "500");
+    });
+
+    it("Shouldn't allow me to propose a transfer of someone else's tokens", async () => {
+      await checkErrorRevert(
+        regulator.requestTransfer(ADDRESS_2, ADDRESS_1, token.address, 500, { from: ADDRESS_1 }),
+        "colony-token-regulator-not-from-address"
+      );
+    });
+
+    it("Shouldn't allow me to cancel someone else's transfer", async () => {
+      await regulator.requestTransfer(ADDRESS_1, ADDRESS_2, token.address, 500, { from: ADDRESS_1 });
+      const transferCount = await regulator.transferCount();
+      await checkErrorRevert(regulator.invalidateRequest(transferCount - 1), "colony-token-regulator-not-from-address");
+    });
+
+    it("Should allow me to cancel a transfer I proposed", async () => {
+      await regulator.requestTransfer(ADDRESS_1, ADDRESS_2, token.address, 500, { from: ADDRESS_1 });
+      const transferCount = await regulator.transferCount();
+      await regulator.invalidateRequest(transferCount - 1, { from: ADDRESS_1 });
+      const transfer = await regulator.transfers(transferCount - 1);
+      assert.equal(transfer.valid, false);
+    });
+
+    it("Should allow an admin to decline a transfer", async () => {
+      await regulator.requestTransfer(ADDRESS_1, ADDRESS_2, token.address, 500, { from: ADDRESS_1 });
+      const transferCount = await regulator.transferCount();
+
+      let transfer = await regulator.transfers(transferCount - 1);
+      assert.equal(transfer.valid, true);
+
+      const txData = await regulator.contract.methods.invalidateRequest(transferCount - 1).encodeABI();
+      await colonyMultiSig.submitTransaction(regulator.address, 0, txData);
+
+      transfer = await regulator.transfers(transferCount - 1);
+      assert.equal(transfer.valid, false);
+    });
+
+    it("should not allow a transfer to be approved more than once", async () => {
+      let txData = await token.contract.methods.mint(1000).encodeABI();
+      await colonyMultiSig.submitTransaction(token.address, 0, txData);
+      txData = await token.contract.methods.transfer(ADDRESS_1, 1000).encodeABI();
+      await colonyMultiSig.submitTransaction(token.address, 0, txData);
+
+      // Make request to regulator
+      await token.approve(regulator.address, 1000, { from: ADDRESS_1 });
+      await regulator.requestTransfer(ADDRESS_1, ADDRESS_2, token.address, 500, { from: ADDRESS_1 });
+
+      const transferCount = await regulator.transferCount();
+
+      // Approve request through multisig
+      txData = await regulator.contract.methods.executeTransfer(transferCount - 1).encodeABI();
+      await colonyMultiSig.submitTransaction(regulator.address, 0, txData);
+
+      const a1BalanceBefore = await token.balanceOf(ADDRESS_1);
+      const a2BalanceBefore = await token.balanceOf(ADDRESS_2);
+
+      await expectEvent(colonyMultiSig.submitTransaction(regulator.address, 0, txData), "ExecutionFailure");
+
+      // Double check balances didn't change
+      const a1BalanceAfter = await token.balanceOf(ADDRESS_1);
+      const a2BalanceAfter = await token.balanceOf(ADDRESS_2);
+
+      assert.equal(a1BalanceAfter.toString(), a1BalanceBefore.toString());
+      assert.equal(a2BalanceAfter.toString(), a2BalanceBefore.toString());
+    });
+  });
+});

--- a/test/vesting.js
+++ b/test/vesting.js
@@ -57,8 +57,17 @@ contract("Vesting", accounts => {
   beforeEach(async () => {
     token = await Token.new("Colony token", "CLNY", 18);
     vesting = await Vesting.new(token.address, colonyMultiSig.address);
+    const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-    const tokenAuthority = await TokenAuthority.new(token.address, vesting.address);
+    const tokenAuthority = await TokenAuthority.new(
+      token.address,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      ZERO_ADDRESS,
+      vesting.address,
+      [ZERO_ADDRESS],
+      ZERO_ADDRESS
+    );
     await token.setAuthority(tokenAuthority.address);
     await token.setOwner(colonyMultiSig.address);
 


### PR DESCRIPTION
Adds a regulator, which is a contract that provides a mechanism for holders to request transfers, and for them to be approved-one-at-a-time by whoever is in control of the regulator.

Also updates other tests to accommodate increased number of parameters for TokenAuthority compared to `develop`.

I'm pretty happy with this, mostly marking as a draft PR for the novelty. I'm certainly open to better names for stuff though (`SimpleRegulator`?)