### PR TITLE
Use https instead of ssh in gitmodules config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/dappsys"]
 	path = lib/dappsys
-	url = git@github.com:dapphub/dappsys-monolithic.git
+	url = https://github.com/dapphub/dappsys-monolithic.git


### PR DESCRIPTION
## Description

This pull request changes the gitmodules configuration to use `https` rather than `ssh`. This is related to issues developers are having using our new cli tool that do not have `ssh` set up on their computer. Although it would be ideal if everyone used `ssh`, this pull request will make the cli tool easier for new developers to spin up colonyNetwork in a local development environment.