### PR TITLE
Introduce WrappedToken

### DIFF
--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -1,0 +1,40 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.5.8;
+
+import "../lib/dappsys/auth.sol";
+
+
+contract Lockable is DSAuth {
+  bool public locked;
+
+  constructor() public {
+    locked = true;
+  }
+
+  modifier unlocked {
+    if (locked) {
+      require(isAuthorized(msg.sender, msg.sig), "colony-token-unauthorised");
+    }
+    _;
+  }
+
+  function unlock() public auth {
+    locked = false;
+  }
+}

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -17,35 +17,28 @@
 
 pragma solidity 0.5.8;
 
-import "../lib/dappsys/auth.sol";
 import "../lib/dappsys/base.sol";
 import "./ERC20Extended.sol";
+import "./Lockable.sol";
 
 
-contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
+contract Token is DSTokenBase(0), ERC20Extended, Lockable {
   uint8 public decimals;
   string public symbol;
   string public name;
 
-  bool public locked;
-
-  modifier unlocked {
-    if (locked) {
-      require(isAuthorized(msg.sender, msg.sig), "colony-token-unauthorised");
-    }
-    _;
-  }
-
-  constructor(string memory _name, string memory _symbol, uint8 _decimals) public {
+  constructor(string memory _name, string memory _symbol, uint8 _decimals)
+    public
+  {
     name = _name;
     symbol = _symbol;
     decimals = _decimals;
-    locked = true;
   }
 
-  function transferFrom(address src, address dst, uint wad) public 
-  unlocked
-  returns (bool)
+  function transferFrom(address src, address dst, uint wad)
+    public
+    unlocked
+    returns (bool)
   {
     return super.transferFrom(src, dst, wad);
   }
@@ -75,11 +68,5 @@ contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
     _balances[guy] = sub(_balances[guy], wad);
     _supply = sub(_supply, wad);
     emit Burn(guy, wad);
-  }
-
-  function unlock() public
-  auth
-  {
-    locked = false;
   }
 }

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -17,28 +17,35 @@
 
 pragma solidity 0.5.8;
 
+import "../lib/dappsys/auth.sol";
 import "../lib/dappsys/base.sol";
 import "./ERC20Extended.sol";
-import "./Lockable.sol";
 
 
-contract Token is DSTokenBase(0), ERC20Extended, Lockable {
+contract Token is DSTokenBase(0), DSAuth, ERC20Extended {
   uint8 public decimals;
   string public symbol;
   string public name;
 
-  constructor(string memory _name, string memory _symbol, uint8 _decimals)
-    public
-  {
+  bool public locked;
+
+  modifier unlocked {
+    if (locked) {
+      require(isAuthorized(msg.sender, msg.sig), "colony-token-unauthorised");
+    }
+    _;
+  }
+
+  constructor(string memory _name, string memory _symbol, uint8 _decimals) public {
     name = _name;
     symbol = _symbol;
     decimals = _decimals;
+    locked = true;
   }
 
-  function transferFrom(address src, address dst, uint wad)
-    public
-    unlocked
-    returns (bool)
+  function transferFrom(address src, address dst, uint wad) public
+  unlocked
+  returns (bool)
   {
     return super.transferFrom(src, dst, wad);
   }
@@ -68,5 +75,11 @@ contract Token is DSTokenBase(0), ERC20Extended, Lockable {
     _balances[guy] = sub(_balances[guy], wad);
     _supply = sub(_supply, wad);
     emit Burn(guy, wad);
+  }
+
+  function unlock() public
+  auth
+  {
+    locked = false;
   }
 }

--- a/contracts/WrappedToken.sol
+++ b/contracts/WrappedToken.sol
@@ -50,6 +50,7 @@ contract WrappedToken is DSTokenBase(0), Lockable {
     emit Withdrawal(msg.sender, wad);
   }
 
+  // Note that transfer() calls this internally, so it's also lockable
   function transferFrom(address src, address dst, uint wad)
     public
     unlocked

--- a/contracts/WrappedToken.sol
+++ b/contracts/WrappedToken.sol
@@ -1,0 +1,60 @@
+/*
+  This file is part of The Colony Network.
+
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity 0.5.8;
+
+import "../lib/dappsys/base.sol";
+import "./Lockable.sol";
+
+
+contract WrappedToken is DSTokenBase(0), Lockable {
+  event  Deposit(address indexed dst, uint256 wad);
+  event  Withdrawal(address indexed src, uint256 wad);
+
+  address public token;
+
+  constructor(address _token) public {
+    token = _token;
+  }
+
+  function deposit(uint256 wad) public {
+    _balances[msg.sender] = add(_balances[msg.sender], wad);
+    _supply = add(_supply, wad);
+
+    require(ERC20(token).transferFrom(msg.sender, address(this), wad), "wrapped-token-transfer-failed");
+
+    emit Deposit(msg.sender, wad);
+  }
+
+  function withdraw(uint256 wad) public unlocked {
+    _balances[msg.sender] = sub(_balances[msg.sender], wad);
+    _supply = sub(_supply, wad);
+
+    // This can't fail, since there's no way to underflow
+    ERC20(token).transfer(msg.sender, wad);
+
+    emit Withdrawal(msg.sender, wad);
+  }
+
+  function transferFrom(address src, address dst, uint wad)
+    public
+    unlocked
+    returns (bool)
+  {
+    return super.transferFrom(src, dst, wad);
+  }
+}

--- a/contracts/WrappedToken.sol
+++ b/contracts/WrappedToken.sol
@@ -31,7 +31,7 @@ contract WrappedToken is DSTokenBase(0), Lockable {
     token = _token;
   }
 
-  function deposit(uint256 wad) public {
+  function deposit(uint256 wad) public unlocked {
     _balances[msg.sender] = add(_balances[msg.sender], wad);
     _supply = add(_supply, wad);
 

--- a/test/wrapped-token.js
+++ b/test/wrapped-token.js
@@ -10,6 +10,7 @@ const { expect } = chai;
 chai.use(bnChai(web3.utils.BN));
 
 const DSTokenBase = artifacts.require("DSTokenBase");
+const TokenAuthority = artifacts.require("TokenAuthority");
 const WrappedToken = artifacts.require("WrappedToken");
 
 contract("Wrapped Token", accounts => {
@@ -18,12 +19,18 @@ contract("Wrapped Token", accounts => {
 
   const USER0 = accounts[0];
   const USER1 = accounts[1];
+  const USER2 = accounts[2];
 
   const WAD = new BN(10).pow(new BN(18));
+
+  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
   beforeEach(async () => {
     token = await DSTokenBase.new(WAD, { from: USER0 });
     wrappedToken = await WrappedToken.new(token.address);
+
+    const tokenAuthority = await TokenAuthority.new(wrappedToken.address, ZERO_ADDRESS, [USER2]);
+    await wrappedToken.setAuthority(tokenAuthority.address);
   });
 
   describe("wrapping tokens", () => {
@@ -75,6 +82,18 @@ contract("Wrapped Token", accounts => {
       expect(balance).to.eq.BN(WAD);
     });
 
+    it("owner can wrap tokens while locked", async () => {
+      await token.approve(wrappedToken.address, WAD, { from: USER0 });
+      await wrappedToken.deposit(WAD, { from: USER0 });
+
+      const balance = await wrappedToken.balanceOf(USER0);
+      expect(balance).to.eq.BN(WAD);
+
+      // Non-owner cannot
+      await checkErrorRevert(wrappedToken.deposit(WAD, { from: USER1 }), "colony-token-unauthorised");
+      await checkErrorRevert(wrappedToken.deposit(WAD, { from: USER2 }), "colony-token-unauthorised");
+    });
+
     it("cannot wrap tokens that don't exist", async () => {
       await token.approve(wrappedToken.address, WAD.addn(1), { from: USER0 });
 
@@ -86,13 +105,25 @@ contract("Wrapped Token", accounts => {
     });
 
     it("cannot unwrap tokens while locked, unless authorized", async () => {
-      await checkErrorRevert(wrappedToken.withdraw(WAD, { from: USER1 }), "colony-token-unauthorised");
+      // Authorised, as owner
       await checkErrorRevert(wrappedToken.withdraw(WAD, { from: USER0 }), "ds-math-sub-underflow");
+
+      // Not authorised
+      await checkErrorRevert(wrappedToken.withdraw(WAD, { from: USER1 }), "colony-token-unauthorised");
+
+      // Not authorised (authority only allows transferring)
+      await checkErrorRevert(wrappedToken.withdraw(WAD, { from: USER2 }), "colony-token-unauthorised");
     });
 
     it("cannot transfer tokens while locked, unless authorized", async () => {
-      await checkErrorRevert(wrappedToken.transfer(USER0, WAD, { from: USER1 }), "colony-token-unauthorised");
-      await checkErrorRevert(wrappedToken.transfer(USER1, WAD, { from: USER0 }), "ds-token-insufficient-balance");
+      // Authorised, as owner
+      await checkErrorRevert(wrappedToken.transfer(USER0, WAD, { from: USER0 }), "ds-token-insufficient-balance");
+
+      // Not authorised
+      await checkErrorRevert(wrappedToken.transfer(USER1, WAD, { from: USER1 }), "colony-token-unauthorised");
+
+      // Authorised, by token authority
+      await checkErrorRevert(wrappedToken.transfer(USER2, WAD, { from: USER2 }), "ds-token-insufficient-balance");
     });
   });
 });

--- a/test/wrapped-token.js
+++ b/test/wrapped-token.js
@@ -1,0 +1,105 @@
+/* globals artifacts */
+
+import BN from "bn.js";
+import chai from "chai";
+import bnChai from "bn-chai";
+
+import { checkErrorRevert } from "../helpers/test-helper";
+
+const { expect } = chai;
+chai.use(bnChai(web3.utils.BN));
+
+const Token = artifacts.require("Token");
+const TokenAuthority = artifacts.require("TokenAuthority");
+const WrappedToken = artifacts.require("WrappedToken");
+
+contract("Wrapped Token", accounts => {
+  const USER0 = accounts[0];
+  const USER1 = accounts[1];
+
+  const WAD = new BN(10).pow(new BN(18));
+  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+  let token;
+  let wrappedToken;
+
+  beforeEach(async () => {
+    token = await Token.new("Colony token", "CLNY", 18);
+    wrappedToken = await WrappedToken.new(token.address);
+
+    const tokenAuthority = await TokenAuthority.new(token.address, ZERO_ADDRESS, [wrappedToken.address]);
+    await token.setAuthority(tokenAuthority.address);
+  });
+
+  describe("wrapping tokens", () => {
+    it("should be able to wrap and unwrap tokens", async () => {
+      await wrappedToken.unlock();
+
+      await token.mint(USER0, WAD, { from: USER0 });
+      await token.approve(wrappedToken.address, WAD, { from: USER0 });
+
+      let balance;
+
+      balance = await token.balanceOf(USER0);
+      expect(balance).to.eq.BN(WAD);
+      balance = await wrappedToken.balanceOf(USER0);
+      expect(balance).to.be.zero;
+
+      await wrappedToken.deposit(WAD, { from: USER0 });
+
+      balance = await token.balanceOf(USER0);
+      expect(balance).to.be.zero;
+      balance = await wrappedToken.balanceOf(USER0);
+      expect(balance).to.eq.BN(WAD);
+
+      await wrappedToken.withdraw(WAD, { from: USER0 });
+
+      balance = await token.balanceOf(USER0);
+      expect(balance).to.eq.BN(WAD);
+      balance = await wrappedToken.balanceOf(USER0);
+      expect(balance).to.be.zero;
+    });
+
+    it("should be able to transfer wrapped tokens", async () => {
+      await wrappedToken.unlock();
+
+      await token.mint(USER0, WAD, { from: USER0 });
+      await token.approve(wrappedToken.address, WAD, { from: USER0 });
+      await wrappedToken.deposit(WAD, { from: USER0 });
+
+      let balance;
+
+      balance = await wrappedToken.balanceOf(USER0);
+      expect(balance).to.eq.BN(WAD);
+      balance = await wrappedToken.balanceOf(USER1);
+      expect(balance).to.be.zero;
+
+      await wrappedToken.transfer(USER1, WAD);
+
+      balance = await wrappedToken.balanceOf(USER0);
+      expect(balance).to.be.zero;
+      balance = await wrappedToken.balanceOf(USER1);
+      expect(balance).to.eq.BN(WAD);
+    });
+
+    it("cannot wrap tokens that don't exist", async () => {
+      await token.approve(wrappedToken.address, WAD, { from: USER0 });
+
+      await checkErrorRevert(wrappedToken.deposit(WAD, { from: USER0 }), "ds-token-insufficient-balance");
+    });
+
+    it("cannot unwrap tokens that don't exist", async () => {
+      await checkErrorRevert(wrappedToken.withdraw(WAD, { from: USER0 }), "ds-math-sub-underflow");
+    });
+
+    it("cannot unwrap tokens while locked, unless authorized", async () => {
+      await checkErrorRevert(wrappedToken.withdraw(WAD, { from: USER1 }), "colony-token-unauthorised");
+      await checkErrorRevert(wrappedToken.withdraw(WAD, { from: USER0 }), "ds-math-sub-underflow");
+    });
+
+    it("cannot transfer tokens while locked, unless authorized", async () => {
+      await checkErrorRevert(wrappedToken.transfer(USER0, WAD, { from: USER1 }), "colony-token-unauthorised");
+      await checkErrorRevert(wrappedToken.transfer(USER1, WAD, { from: USER0 }), "ds-token-insufficient-balance");
+    });
+  });
+});


### PR DESCRIPTION
Introduce `WrappedToken.sol` to allow us to wrap the CLNY ERC20 on xDai. Implements the ERC20 standard plus the "locking" functionality originally developed for the CLNY token.