### PR TITLE
Update VestingSimple after audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ test-accounts.json
 ganache-accounts.json
 test-results.xml
 coverage.json
+/coverage
 /coverage-contracts
 /migrations/coverage
 /flattened/*

--- a/README.md
+++ b/README.md
@@ -30,20 +30,22 @@ CLNY Token contract based on an ERC20 token with `mint` and `burn` functionality
 [TokenAuthority.sol](./contracts/TokenAuthority.sol)
 Acts as the Token Authority while CLNY Token is locked for token transfers. Implements `DSAuthority` to allow Colony MultiSig, Vesting and other necessary contracts to be able to transfer tokens for the purposes of pre-allocating tokens and token grants as well as the general functioning of the Colony Network. This is an immutable set of permissions which can be reviewed in the contract itself.
 
-[Vesting.sol](./contracts/Vesting.sol) 
+[VestingSimple.sol](./contracts/VestingSimple.sol)
 Stores and manages the CLNY Token grants via the following functions:
 
-Secured to Colony MultiSig only:
-* `addTokenGrant` - Adds a new token grant for a given user. Only one grant per user is allowed. The amount of CLNY grant tokens here need to be preapproved by the Colony MultiSig (which mints and owns the tokens) for transfer by the `Vesting` contract before this call. There is an option to backdate the grant here if needed.
+Secured to contract owner only:
+* `setGrant` - Adds a new token grant for a given user. Only one grant per user is allowed. The grant may be increased or decreased after the fact, but not less than any amount already claimed. Grants may also be added after activation, with vesting calculated from the time of activation.
 
-* `removeTokenGrant` - Terminate token grant for a given user transferring all vested tokens to the user and returning all non-vested tokens to the Colony MultiSig.
+* `setGrants` - Call `setGrant` on an array of addresses and values. A convenience function.
+
+* `activate` - Allows users to begin claiming token grants, with vesting calculated from the timestamp of the activating transaction.
+
+* `withdraw` - Withdraw any excess tokens from the contract and return them to the contract owner.
 
 Public functions:
-* `claimVestedTokens` - Allows a grant recipient to claim their vested tokens. Errors if no tokens have vested. Note that it is advised recipients check they are entitled to claim via `calculateGrantClaim` before calling this.
+* `claimGrant` - Allows a grant recipient to claim their vested tokens. Errors if no tokens have vested. Note that it is advised recipients check they are entitled to claim via `getClaimable` before calling this.
 
-* `calculateGrantClaim` - Calculates the vested and unclaimed months and tokens available for a given user to claim. Due to rounding errors once grant duration is reached, returns the entire left grant amount. Returns (0, 0) if cliff has not been reached.
-
-The Colony Multisignature contract is defined in gnosis-multisig/contracts/MultiSigWallet.sol and based on the [Gnosis MultiSig](https://github.com/gnosis/MultiSigWallet)
+* `getClaimable` - Calculates the amount of tokens currently claimable by a user.
 
 ## Testing
 

--- a/contracts/VestingSimple.sol
+++ b/contracts/VestingSimple.sol
@@ -35,7 +35,7 @@ contract VestingSimple is DSMath, DSAuth {
   uint256 public vestingDuration; // The period of time (in seconds) over which the vesting occurs
   uint256 public startTime; // The timestamp of activation, when vesting begins
 
-  uint256 public totalGrants; // Sum of all grants
+  uint256 public totalAmount; // Sum of all grant amounts
   uint256 public totalClaimed; // Sum of all claimed tokens
 
   struct Grant {
@@ -66,7 +66,7 @@ contract VestingSimple is DSMath, DSAuth {
     Grant storage grant = grants[_recipient];
     require(grant.claimed <= _amount, "vesting-simple-bad-amount");
 
-    totalGrants = add(_amount, sub(totalGrants, grant.amount));
+    totalAmount = add(_amount, sub(totalAmount, grant.amount));
     grant.amount = _amount;
 
     emit GrantSet(_recipient, _amount);
@@ -87,7 +87,9 @@ contract VestingSimple is DSMath, DSAuth {
 
     grant.claimed = add(grant.claimed, claimable);
     totalClaimed = add(totalClaimed, claimable);
+
     assert(grant.amount >= grant.claimed);
+    assert(totalAmount >= totalClaimed);
 
     require(token.transfer(msg.sender, claimable), "vesting-simple-transfer-failed");
 

--- a/contracts/VestingSimple.sol
+++ b/contracts/VestingSimple.sol
@@ -29,14 +29,14 @@ contract VestingSimple is DSMath, DSAuth {
   event GrantSet(address recipient, uint256 amount);
   event GrantClaimed(address recipient, uint256 claimed);
 
-  Token public token;
+  Token public token; // The token being distributed
 
-  uint256 public initialClaimable;
-  uint256 public vestingDuration;
-  uint256 public startTime;
+  uint256 public initialClaimable; // The amount of tokens claimable upon activation
+  uint256 public vestingDuration; // The period of time (in seconds) over which the vesting occurs
+  uint256 public startTime; // The timestamp of activation, when vesting begins
 
-  uint256 public totalGrants;
-  uint256 public totalClaimed;
+  uint256 public totalGrants; // Sum of all grants
+  uint256 public totalClaimed; // Sum of all claimed tokens
 
   struct Grant {
     uint256 amount;

--- a/test/vesting-simple.js
+++ b/test/vesting-simple.js
@@ -148,6 +148,12 @@ contract("Vesting Simple", accounts => {
       await checkErrorRevert(vesting.activate(), "vesting-simple-already-active");
     });
 
+    it("cannot claim a grant if the contract has no tokens", async () => {
+      await vesting.withdraw(GRANT);
+
+      await checkErrorRevert(vesting.claimGrant({ from: USER1 }), "ds-token-insufficient-balance");
+    });
+
     it("can claim BASE number of tokens immediately", async () => {
       const balancePre = await token.balanceOf(USER1);
 

--- a/test/vesting-simple.js
+++ b/test/vesting-simple.js
@@ -4,7 +4,7 @@ import chai from "chai";
 import bnChai from "bn-chai";
 import BN from "bn.js";
 
-import { checkErrorRevert, currentBlockTime, forwardTime, makeTxAtTimestamp, startMining } from "../helpers/test-helper";
+import {checkErrorRevert, currentBlockTime, forwardTime, makeTxAtTimestamp, startMining} from "../helpers/test-helper";
 
 const {expect} = chai;
 chai.use(bnChai(web3.utils.BN));
@@ -151,11 +151,11 @@ contract("Vesting Simple", accounts => {
     it("cannot claim a grant if the contract has no tokens", async () => {
       await vesting.withdraw(GRANT);
 
-      await checkErrorRevert(vesting.claimGrant({ from: USER1 }), "ds-token-insufficient-balance");
+      await checkErrorRevert(vesting.claimGrant({from: USER1}), "ds-token-insufficient-balance");
     });
 
     it("cannot claim a non-existent grant", async () => {
-      await checkErrorRevert(vesting.claimGrant({ from: USER0 }), "vesting-simple-nothing-to-claim");
+      await checkErrorRevert(vesting.claimGrant({from: USER0}), "vesting-simple-nothing-to-claim");
     });
 
     it("can claim BASE number of tokens immediately", async () => {
@@ -251,18 +251,18 @@ contract("Vesting Simple", accounts => {
     });
 
     it("can track the total amount of grants", async () => {
-      let totalGrants;
+      let totalAmount;
 
-      totalGrants = await vesting.totalGrants();
-      expect(totalGrants).to.eq.BN(GRANT);
+      totalAmount = await vesting.totalAmount();
+      expect(totalAmount).to.eq.BN(GRANT);
 
       await vesting.setGrant(USER0, WAD);
-      totalGrants = await vesting.totalGrants();
-      expect(totalGrants).to.eq.BN(GRANT.add(WAD));
+      totalAmount = await vesting.totalAmount();
+      expect(totalAmount).to.eq.BN(GRANT.add(WAD));
 
       await vesting.setGrant(USER0, 0);
-      totalGrants = await vesting.totalGrants();
-      expect(totalGrants).to.eq.BN(GRANT);
+      totalAmount = await vesting.totalAmount();
+      expect(totalAmount).to.eq.BN(GRANT);
     });
 
     it("can track the total amount claimed", async () => {
@@ -273,11 +273,11 @@ contract("Vesting Simple", accounts => {
 
       let totalClaimed;
 
-      await vesting.claimGrant({ from: USER0 });
+      await vesting.claimGrant({from: USER0});
       totalClaimed = await vesting.totalClaimed();
       expect(totalClaimed).to.eq.BN(GRANT);
 
-      await vesting.claimGrant({ from: USER1 });
+      await vesting.claimGrant({from: USER1});
       totalClaimed = await vesting.totalClaimed();
       expect(totalClaimed).to.eq.BN(GRANT.muln(2));
     });

--- a/test/vesting-simple.js
+++ b/test/vesting-simple.js
@@ -154,6 +154,10 @@ contract("Vesting Simple", accounts => {
       await checkErrorRevert(vesting.claimGrant({ from: USER1 }), "ds-token-insufficient-balance");
     });
 
+    it("cannot claim a non-existent grant", async () => {
+      await checkErrorRevert(vesting.claimGrant({ from: USER0 }), "vesting-simple-nothing-to-claim");
+    });
+
     it("can claim BASE number of tokens immediately", async () => {
       const balancePre = await token.balanceOf(USER1);
 


### PR DESCRIPTION
Update vesting contract with audit feedback. Specifically:

- Made external the functions which have no internal calls to save gas
- Track `totalAmount` and `totalClaimed` across all grants
- Check results of token transfer operations
- Return a claimable balance of 0 if the contract is inactive
- Added a few more tests
- Also, updated the README with usage instructions